### PR TITLE
Implementing SHA2-256 Cryptographic Hash Function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXX_FLAGS = -Wall -std=c++20
 SYCL_FLAGS = -fsycl
 SYCL_CUDA_FLAGS = -fsycl-targets=nvptx64-nvidia-cuda
 SYCL_CPU_FLAGS = -fsycl-targets=spir64_x86_64
-SYCL_GPU_FLAGS = $(SYCL_GPU_FLAGS)
+SYCL_GPU_FLAGS = -fsycl-targets=spir64_gen
 OPT_FLAGS = -O3
 IFLAGS = -I./include
 SHA_VARIANT = -D$(shell echo $(or $(SHA),sha2_256) | tr a-z A-Z)

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ SYCL_CPU_FLAGS = -fsycl-targets=spir64_x86_64
 SYCL_GPU_FLAGS = $(SYCL_GPU_FLAGS)
 OPT_FLAGS = -O3
 IFLAGS = -I./include
+SHA_VARIANT = -D$(shell echo $(or $(SHA),sha2_256) | tr a-z A-Z)
 
 all: test_impl
 
 test/a.out: test/main.cpp include/*.hpp
-	$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $< -o $@
+	$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $< -o $@
 
 test_impl: test/a.out
 	./test/a.out
@@ -24,7 +25,7 @@ format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
 
 bench/a.out: bench/main.cpp include/*.hpp
-	$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $< -o $@
+	$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $< -o $@
 
 benchmark: bench/a.out
 	./bench/a.out
@@ -32,16 +33,16 @@ benchmark: bench/a.out
 aot_cpu:
 	@if lscpu | grep -q 'avx512'; then \
 		echo "Using avx512"; \
-		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=avx512" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=avx512" bench/main.cpp -o bench/a.out; \
 	elif lscpu | grep -q 'avx2'; then \
 		echo "Using avx2"; \
-		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=avx2" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=avx2" bench/main.cpp -o bench/a.out; \
 	elif lscpu | grep -q 'avx'; then \
 		echo "Using avx"; \
-		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=avx" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=avx" bench/main.cpp -o bench/a.out; \
 	elif lscpu | grep -q 'sse4.2'; then \
 		echo "Using sse4.2"; \
-		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=sse4.2" bench/main.cpp -o bench/a.out; \
+		$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $(SYCL_CPU_FLAGS) -Xs "-march=sse4.2" bench/main.cpp -o bench/a.out; \
 	else \
 		echo "Can't AOT compile using avx, avx2, avx512 or sse4.2"; \
 	fi
@@ -51,9 +52,9 @@ aot_gpu:
 	# you may want to replace `device` identifier with `0x3e96` if you're targeting *Intel(R) UHD Graphics P630*
 	#
 	# otherwise, let it be what it's if you're targeting *Intel(R) Iris(R) Xe MAX Graphics*
-	$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(IFLAGS) $(SYCL_GPU_FLAGS) -Xs "-device 0x4905" bench/main.cpp -o bench/a.out
+	$(CXX) $(CXX_FLAGS) $(SYCL_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) $(SYCL_GPU_FLAGS) -Xs "-device 0x4905" bench/main.cpp -o bench/a.out
 	./bench/a.out
 
 cuda:
-	clang++ $(CXX_FLAGS) $(SYCL_FLAGS) $(SYCL_CUDA_FLAGS) $(OPT_FLAGS) $(IFLAGS) bench/main.cpp -o bench/a.out
+	clang++ $(CXX_FLAGS) $(SYCL_FLAGS) $(SYCL_CUDA_FLAGS) $(OPT_FLAGS) $(SHA_VARIANT) $(IFLAGS) bench/main.cpp -o bench/a.out
 	./bench/a.out

--- a/README.md
+++ b/README.md
@@ -1,2 +1,115 @@
 # merklize-sha
-SYCL accelerated Binary Merklization using Secure Hash Standard and SHA3
+
+SYCL accelerated Binary Merklization using SHA1, SHA2 & SHA3
+
+## Motivation
+
+After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 families of cryptographic hash functions are data parallel, requiring to process each message block sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2 families of cryptographic hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
+
+```bash
+  ((a, b), (c, d))          < --- [Level 1] [Root]
+     /       \
+    /         \
+ (a, b)      (c, d)         < --- [Level 2] [Intermediates]
+  / \        /  \
+ /   \      /    \
+a     b     c     d         < --- [Level 3] [Leaves]
+```
+
+I'd also like you to note that, computation of nodes of level-i of tree are data dependent on level-(i + 1).
+
+When N is power of 2 and those many nodes are provided as input, (N - 1) -many intermediates to be computed. For that reason, size of allocated memory for output is of same size as input is. That means, very first few bytes ( = digest size of hash function in use ) of output memory allocation will be empty. To be more specific, if SHA2-224 is our choice of hash function, then first 28 -bytes of output memory allocation will not be of interest, but skipping that next 28 -bytes chunk should have root of tree, once offloaded computation finishes its execution.
+
+```bash
+input   = [a, b, c, d]
+output  = [0, ((a, b), (c, d)), (a, b), (c, d)]
+```
+
+Here in this repository, I'm keeping binary merklization kernel, implemented in SYCL, using SHA1/ SHA2 variants as 2-to-1 hash function, which one to use is compile-time choice using pre-processor directive.
+
+If you happen to be interested in Binary Merklization using Rescue Prime Hash/ BLAKE3, consider seeing following links.
+
+- [Binary Merklization using Rescue Prime Hash](https://github.com/itzmeanjan/ff-gpu)
+- [Binary Merklization using BLAKE3](https://github.com/itzmeanjan/blake3)
+
+> During SHA1, SHA2 implementations, I've followed Secure Hash Standard [specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf).
+
+> Using SHA1 for binary merklization may not be a good choice these days, see [here](https://csrc.nist.gov/Projects/Hash-Functions/NIST-Policy-on-Hash-Functions). But still I'm keeping SHA1 implementation, just as a reference.
+
+## Prerequisites
+
+- I'm using 
+
+```bash
+$ lsb_release -d
+
+Description:    Ubuntu 20.04.3 LTS
+```
+
+- You should have Intel's DPCPP compiler, which is an open-source llvm-based SYCL specification's implementation; see [here](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html)
+
+```bash
+$ dpcpp --version
+
+Intel(R) oneAPI DPC++/C++ Compiler 2022.0.0 (2022.0.0.20211123)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /opt/intel/oneapi/compiler/2022.0.2/linux/bin-llvm
+```
+
+- If you're planning to target Nvidia GPU, I suggest you compile aforementioned toolchain from source; see [here](https://intel.github.io/llvm-docs/GetStartedGuide.html#prerequisites)
+
+```bash
+$ clang++ --version
+
+clang version 14.0.0 (https://github.com/intel/llvm c690ac8d771e8bb1a1be651872b782f4044d936c)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /home/ubuntu/sycl_workspace/llvm/build/bin
+```
+
+- You will also need to have `make` utility for easily running compilation flow, along with that `clang-format` for source formatting can be helpful.
+- Another useful tool to have is `sycl-info`, for quickly checking available SYCL implementation related details; see [here](https://github.com/codeplaysoftware/sycl-info)
+
+## Usage
+
+If you happen to be interested in 2-to-1 hash implementation of
+
+- [SHA1](https://github.com/itzmeanjan/merklize-sha/blob/c0a8c0155b5bed04a7693b815d257acb68effcb8/example/sha1.cpp)
+- [SHA2-224](https://github.com/itzmeanjan/merklize-sha/blob/c03e42c0502a9d8104609c9f64033afbf6eac81a/example/sha2_224.cpp)
+- [SHA2-256](https://github.com/itzmeanjan/merklize-sha/blob/c03e42c0502a9d8104609c9f64033afbf6eac81a/example/sha2_256.cpp)
+
+where two digests of respective hash functions are input, in byte concatenated form, to `hash( ... )` function, consider taking a look at above hyperlinked examples.
+
+You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/f2eb91733e193de9913e7cb9622c199b77534fcc/include/merklize.hpp)
+
+## Tests
+
+I've accompanied each hash function implementation along with binary merklization using them, with test cases which can be compiled and executed as
+
+```bash
+SHA=sha1 make; make clean
+SHA=sha2_224 make; make clean
+SHA=sha2_256 make; make clean
+```
+
+## Benchmarks
+
+For benchmarking binary merklization, I'm taking randomly generated N -many leaf nodes as input, which are explicitly transferred to accelerator's memory; computing all (N - 1) -many intermediate nodes; finally transferring them back to host memory. This flow is executed 8 times, before taking average of kernel execution/ host <-> device data tx time, for some N.
+
+I'm keeping binary merklization benchmark results of
+
+- SHA1
+  - [Nvidia GPU(s)](results/sha1/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha1/intel_cpu.md)
+  - [Intel GPU(s)](results/sha1/intel_gpu.md)
+- SHA2-224
+  - [Nvidia GPU(s)](results/sha2-224/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha2-224/intel_cpu.md)
+  - [Intel GPU(s)](results/sha2-224/intel_gpu.md)
+- SHA2-256
+  - [Nvidia GPU(s)](results/sha2-256/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha2-256/intel_cpu.md)
+  - [Intel GPU(s)](results/sha2-256/intel_gpu.md)
+
+obtained after executing them on multiple accelerators.

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -38,8 +38,17 @@ main(int argc, char** argv)
 
   double* ts = (double*)std::malloc(sizeof(double) * 3);
 
+#if defined SHA1
   std::cout << "\nBenchmarking Binary Merklization using SHA1" << std::endl
             << std::endl;
+#elif defined SHA2_224
+  std::cout << "\nBenchmarking Binary Merklization using SHA2-224" << std::endl
+            << std::endl;
+#elif defined SHA2_256
+  std::cout << "\nBenchmarking Binary Merklization using SHA2-256" << std::endl
+            << std::endl;
+#endif
+
   std::cout << std::setw(16) << std::right << "leaf count"
             << "\t\t" << std::setw(16) << std::right << "execution time"
             << "\t\t" << std::setw(16) << std::right << "host-to-device tx time"

--- a/example/sha1.cpp
+++ b/example/sha1.cpp
@@ -5,13 +5,14 @@
 int
 main(int argc, char** argv)
 {
-  // a = [0xff] * 20
+  // $ python3
+  // >>> a = [0xff] * 20
   //
   // first input digest
   constexpr sycl::uchar digest_0[20] = { 255, 255, 255, 255, 255, 255, 255,
                                          255, 255, 255, 255, 255, 255, 255,
                                          255, 255, 255, 255, 255, 255 };
-  // b = [0x0f] * 20
+  // >>> b = [0x0f] * 20
   //
   // second input digest
   constexpr sycl::uchar digest_1[20] = {

--- a/example/sha1.cpp
+++ b/example/sha1.cpp
@@ -1,0 +1,74 @@
+#include "sha1.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA1 hash function !
+int
+main(int argc, char** argv)
+{
+  // a = [0xff] * 20
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[20] = { 255, 255, 255, 255, 255, 255, 255,
+                                         255, 255, 255, 255, 255, 255, 255,
+                                         255, 255, 255, 255, 255, 255 };
+  // b = [0x0f] * 20
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[20] = {
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15
+  };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha1(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[20] = { 75,  214, 120, 118, 80,  218, 70,
+                                         167, 98,  76,  218, 115, 156, 23,
+                                         96,  238, 203, 169, 232, 21 };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  q.single_task<class kernelExampleSHA1>([=]() {
+    sycl::uchar padded[64];
+    sycl::uint parsed[16];
+    sycl::uint digest[5];
+
+    // pad input so that it's a full message block
+    sha1::pad_input_message(in, padded);
+    // parse message block into words
+    sha1::parse_message_words(padded, parsed);
+    // now compute SHA1 on input words
+    sha1::hash(parsed, digest);
+    // convert SHA1 digest words to big endian bytes
+    sha1::words_to_be_bytes(digest, out);
+  });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/example/sha2_224.cpp
+++ b/example/sha2_224.cpp
@@ -1,0 +1,85 @@
+#include "sha2_224.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA2-224 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 28
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[28] = { 255, 255, 255, 255, 255, 255, 255,
+                                         255, 255, 255, 255, 255, 255, 255,
+                                         255, 255, 255, 255, 255, 255, 255,
+                                         255, 255, 255, 255, 255, 255, 255 };
+  // >>> b = [0x0f] * 28
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[28] = { 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15 };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha224(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[28] = { 168, 239, 85,  136, 55,  216, 197,
+                                         106, 126, 224, 146, 191, 38,  143,
+                                         213, 130, 52,  170, 14,  66,  157,
+                                         155, 179, 118, 194, 193, 205, 83 };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  q.single_task<class kernelExampleSHA1>([=]() {
+    sycl::uchar padded[128];
+    sycl::uint parsed[32];
+    sycl::uint digest[7];
+
+    // pad input so that it's a full message block
+    sha2_224::pad_input_message(in, padded);
+
+    // parse message block into words
+#pragma unroll 16
+    for (size_t i = 0; i < 32; i++) {
+      parsed[i] = from_be_bytes_to_words(padded + i * 4);
+    }
+
+    // now compute SHA2-224 on input words
+    sha2_224::hash(parsed, digest);
+
+    // convert SHA2-224 digest words to big endian bytes
+#pragma unroll 7
+    for (size_t i = 0; i < 7; i++) {
+      from_words_to_be_bytes(*(digest + i), out + i * 4);
+    }
+  });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -4,7 +4,12 @@
 #include <random>
 
 // Benchmarks binary merklization implementation --- collects motivation from
-// https://github.com/itzmeanjan/blake3/blob/e2a1340a9a7972854889d494b450d72c2198cace/include/merklize.hpp#L4-L12
+// https://github.com/itzmeanjan/blake3/blob/e2a1340/include/bench_merklize.hpp#L6-L10
+//
+// Which SHA variant of 2-to-1 hash function to be used in a compile-time
+// decision using preprocessor directives
+//
+// If none chosen, SHA2-256 is chosen by default !
 void
 benchmark_merklize(sycl::queue& q,
                    size_t leaf_cnt,
@@ -35,8 +40,8 @@ benchmark_merklize(sycl::queue& q,
 
   // Set all intermediate nodes to zero bytes,
   //
-  // I'll make use of this fact later to assert that first digest bytes will
-  // never be touched by any work-item
+  // I'll make use of this fact later to assert that first digest bytes (
+  // different for each SHA variant ) will never be touched by any work-item
   q.memset(o_d, 0, o_size).wait();
 
   {
@@ -64,7 +69,8 @@ benchmark_merklize(sycl::queue& q,
   // time device to host data tx command
   ts_2 = time_event(evt_1);
 
-  // ensuring that first digest bytes are never touched by any work-items
+  // ensuring that first digest bytes ( different for each SHA variant ) are
+  // never touched by any work-items
   for (size_t i = 0; i < (
 
 #if defined SHA1

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -16,8 +16,16 @@ benchmark_merklize(sycl::queue& q,
   // required to be merklized
   assert(leaf_cnt >= (1 << 20));
 
-  const size_t i_size = leaf_cnt * sha1::OUT_LEN_BYTES;
-  const size_t o_size = leaf_cnt * sha1::OUT_LEN_BYTES;
+#if defined SHA1
+  const size_t i_size = leaf_cnt * sha1::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha1::OUT_LEN_BYTES; // in bytes
+#elif defined SHA2_224
+  const size_t i_size = leaf_cnt * sha2_224::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha2_224::OUT_LEN_BYTES; // in bytes
+#elif defined SHA2_256
+  const size_t i_size = leaf_cnt * sha2_256::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha2_256::OUT_LEN_BYTES; // in bytes
+#endif
 
   // allocate resources
   sycl::uint* i_h = static_cast<sycl::uint*>(sycl::malloc_host(i_size, q));
@@ -27,8 +35,8 @@ benchmark_merklize(sycl::queue& q,
 
   // Set all intermediate nodes to zero bytes,
   //
-  // I'll make use of this fact later to assert that first 20 -bytes will never
-  // be touched by any work-item
+  // I'll make use of this fact later to assert that first digest bytes will
+  // never be touched by any work-item
   q.memset(o_d, 0, o_size).wait();
 
   {
@@ -56,8 +64,20 @@ benchmark_merklize(sycl::queue& q,
   // time device to host data tx command
   ts_2 = time_event(evt_1);
 
-  // ensuring that first 20 -bytes are never touched by any work-items
-  for (size_t i = 0; i < (sha1::OUT_LEN_BYTES >> 2); i++) {
+  // ensuring that first digest bytes are never touched by any work-items
+  for (size_t i = 0; i < (
+
+#if defined SHA1
+                           sha1::OUT_LEN_BYTES
+#elif defined SHA2_224
+                           sha2_224::OUT_LEN_BYTES
+#elif defined SHA2_256
+                           sha2_256::OUT_LEN_BYTES
+#endif
+
+                           >> 2);
+
+       i++) {
     assert(*(o_h + i) == 0);
   }
 

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -6,15 +6,13 @@
 
 #if defined SHA1
 #include "sha1.hpp"
-#pragma message "Choosing to compile with SHA1 !"
+#pragma message "Choosing to compile Merklization with SHA1 !"
 #elif defined SHA2_224
 #include "sha2_224.hpp"
-#pragma message "Choosing to compile with SHA2-224 !"
+#pragma message "Choosing to compile Merklization with SHA2-224 !"
 #elif defined SHA2_256
 #include "sha2_256.hpp"
-#pragma message "Choosing to compile with SHA2-256 !"
-#else
-#error "Nothing to compile with !"
+#pragma message "Choosing to compile Merklization with SHA2-256 !"
 #endif
 
 // Binary merklization --- collects motivation from

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -1,5 +1,16 @@
 #pragma once
+
+#ifndef SHA
+#define SHA sha1
+#endif
+
+#if SHA == sha1
 #include "sha1.hpp"
+#elif SHA == sha2_224
+#include "sha2_224.hpp"
+#elif SHA == sha2_256
+#include "sha2_256.hpp"
+#endif
 
 // Binary merklization --- collects motivation from
 // https://github.com/itzmeanjan/blake3/blob/e2a1340a9a7972854889d494b450d72c2198cace/include/merklize.hpp#L4-L12
@@ -19,8 +30,16 @@ merklize(sycl::queue& q,
   // Note N = power of 2
   assert(leaf_cnt == itmd_cnt + 1);
 
+#if SHA == sha1
   assert(i_size == leaf_cnt * sha1::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha1::OUT_LEN_BYTES);
+#elif SHA == sha2_224
+  assert(i_size == leaf_cnt * sha2_224::OUT_LEN_BYTES);
+  assert(o_size == (itmd_cnt + 1) * sha2_224::OUT_LEN_BYTES);
+#elif SHA == sha2_256
+  assert(i_size == leaf_cnt * sha2_256::OUT_LEN_BYTES);
+  assert(o_size == (itmd_cnt + 1) * sha2_256::OUT_LEN_BYTES);
+#endif
 
   // both input and output allocation has same size
   assert(i_size == o_size);
@@ -55,13 +74,33 @@ merklize(sycl::queue& q,
       [=](sycl::nd_item<1> it) {
         const size_t idx = it.get_global_linear_id();
 
+#if SHA == sha1
         const size_t in_idx = idx * (sha1::IN_LEN_BYTES >> 2);
         const size_t out_idx = idx * (sha1::OUT_LEN_BYTES >> 2);
 
         sycl::uint padded[16];
+#elif SHA == sha2_224
+        const size_t in_idx = idx * (sha2_224::IN_LEN_BYTES >> 2);
+        const size_t out_idx = idx * (sha2_224::OUT_LEN_BYTES >> 2);
 
+        sycl::uint padded[32];
+#elif SHA == sha2_256
+        const size_t in_idx = idx * (sha2_256::IN_LEN_BYTES >> 2);
+        const size_t out_idx = idx * (sha2_256::OUT_LEN_BYTES >> 2);
+
+        sycl::uint padded[32];
+#endif
+
+#if SHA == sha1
         sha1::pad_input_message(leaf_nodes + i_offset + in_idx, padded);
         sha1::hash(padded, intermediates + o_offset + out_idx);
+#elif SHA == sha2_224
+        sha2_224::pad_input_message(leaf_nodes + i_offset + in_idx, padded);
+        sha2_224::hash(padded, intermediates + o_offset + out_idx);
+#elif SHA == sha2_256
+        sha2_256::pad_input_message(leaf_nodes + i_offset + in_idx, padded);
+        sha2_256::hash(padded, intermediates + o_offset + out_idx);
+#endif
       });
   });
 
@@ -102,13 +141,35 @@ merklize(sycl::queue& q,
         [=](sycl::nd_item<1> it) {
           const size_t idx = it.get_global_linear_id();
 
+#if SHA == sha1
           const size_t in_idx = idx * (sha1::IN_LEN_BYTES >> 2);
           const size_t out_idx = idx * (sha1::OUT_LEN_BYTES >> 2);
 
           sycl::uint padded[16];
+#elif SHA == sha2_224
+          const size_t in_idx = idx * (sha2_224::IN_LEN_BYTES >> 2);
+          const size_t out_idx = idx * (sha2_224::OUT_LEN_BYTES >> 2);
 
+          sycl::uint padded[32];
+#elif SHA == sha2_256
+          const size_t in_idx = idx * (sha2_256::IN_LEN_BYTES >> 2);
+          const size_t out_idx = idx * (sha2_256::OUT_LEN_BYTES >> 2);
+
+          sycl::uint padded[32];
+#endif
+
+#if SHA == sha1
           sha1::pad_input_message(intermediates + i_offset_ + in_idx, padded);
           sha1::hash(padded, intermediates + o_offset_ + out_idx);
+#elif SHA == sha2_224
+          sha2_224::pad_input_message(intermediates + i_offset_ + in_idx,
+                                      padded);
+          sha2_224::hash(padded, intermediates + o_offset_ + out_idx);
+#elif SHA == sha2_256
+          sha2_256::pad_input_message(intermediates + i_offset_ + in_idx,
+                                      padded);
+          sha2_256::hash(padded, intermediates + o_offset_ + out_idx);
+#endif
         });
     });
     evts_0.push_back(evt_1);

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -1,15 +1,20 @@
 #pragma once
 
-#ifndef SHA
-#define SHA sha1
+#if !(defined SHA1 || defined SHA2_224 || defined SHA2_256)
+#define SHA2_256
 #endif
 
-#if SHA == sha1
+#if defined SHA1
 #include "sha1.hpp"
-#elif SHA == sha2_224
+#pragma message "Choosing to compile with SHA1 !"
+#elif defined SHA2_224
 #include "sha2_224.hpp"
-#elif SHA == sha2_256
+#pragma message "Choosing to compile with SHA2-224 !"
+#elif defined SHA2_256
 #include "sha2_256.hpp"
+#pragma message "Choosing to compile with SHA2-256 !"
+#else
+#error "Nothing to compile with !"
 #endif
 
 // Binary merklization --- collects motivation from
@@ -30,13 +35,13 @@ merklize(sycl::queue& q,
   // Note N = power of 2
   assert(leaf_cnt == itmd_cnt + 1);
 
-#if SHA == sha1
+#if defined SHA1
   assert(i_size == leaf_cnt * sha1::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha1::OUT_LEN_BYTES);
-#elif SHA == sha2_224
+#elif defined SHA2_224
   assert(i_size == leaf_cnt * sha2_224::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha2_224::OUT_LEN_BYTES);
-#elif SHA == sha2_256
+#elif defined SHA2_256
   assert(i_size == leaf_cnt * sha2_256::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha2_256::OUT_LEN_BYTES);
 #endif
@@ -74,30 +79,30 @@ merklize(sycl::queue& q,
       [=](sycl::nd_item<1> it) {
         const size_t idx = it.get_global_linear_id();
 
-#if SHA == sha1
+#if defined SHA1
         const size_t in_idx = idx * (sha1::IN_LEN_BYTES >> 2);
         const size_t out_idx = idx * (sha1::OUT_LEN_BYTES >> 2);
 
         sycl::uint padded[16];
-#elif SHA == sha2_224
+#elif defined SHA2_224
         const size_t in_idx = idx * (sha2_224::IN_LEN_BYTES >> 2);
         const size_t out_idx = idx * (sha2_224::OUT_LEN_BYTES >> 2);
 
         sycl::uint padded[32];
-#elif SHA == sha2_256
+#elif defined SHA2_256
         const size_t in_idx = idx * (sha2_256::IN_LEN_BYTES >> 2);
         const size_t out_idx = idx * (sha2_256::OUT_LEN_BYTES >> 2);
 
         sycl::uint padded[32];
 #endif
 
-#if SHA == sha1
+#if defined SHA1
         sha1::pad_input_message(leaf_nodes + i_offset + in_idx, padded);
         sha1::hash(padded, intermediates + o_offset + out_idx);
-#elif SHA == sha2_224
+#elif defined SHA2_224
         sha2_224::pad_input_message(leaf_nodes + i_offset + in_idx, padded);
         sha2_224::hash(padded, intermediates + o_offset + out_idx);
-#elif SHA == sha2_256
+#elif defined SHA2_256
         sha2_256::pad_input_message(leaf_nodes + i_offset + in_idx, padded);
         sha2_256::hash(padded, intermediates + o_offset + out_idx);
 #endif
@@ -141,31 +146,31 @@ merklize(sycl::queue& q,
         [=](sycl::nd_item<1> it) {
           const size_t idx = it.get_global_linear_id();
 
-#if SHA == sha1
+#if defined SHA1
           const size_t in_idx = idx * (sha1::IN_LEN_BYTES >> 2);
           const size_t out_idx = idx * (sha1::OUT_LEN_BYTES >> 2);
 
           sycl::uint padded[16];
-#elif SHA == sha2_224
+#elif defined SHA2_224
           const size_t in_idx = idx * (sha2_224::IN_LEN_BYTES >> 2);
           const size_t out_idx = idx * (sha2_224::OUT_LEN_BYTES >> 2);
 
           sycl::uint padded[32];
-#elif SHA == sha2_256
+#elif defined SHA2_256
           const size_t in_idx = idx * (sha2_256::IN_LEN_BYTES >> 2);
           const size_t out_idx = idx * (sha2_256::OUT_LEN_BYTES >> 2);
 
           sycl::uint padded[32];
 #endif
 
-#if SHA == sha1
+#if defined SHA1
           sha1::pad_input_message(intermediates + i_offset_ + in_idx, padded);
           sha1::hash(padded, intermediates + o_offset_ + out_idx);
-#elif SHA == sha2_224
+#elif defined SHA2_224
           sha2_224::pad_input_message(intermediates + i_offset_ + in_idx,
                                       padded);
           sha2_224::hash(padded, intermediates + o_offset_ + out_idx);
-#elif SHA == sha2_256
+#elif defined SHA2_256
           sha2_256::pad_input_message(intermediates + i_offset_ + in_idx,
                                       padded);
           sha2_256::hash(padded, intermediates + o_offset_ + out_idx);

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -16,7 +16,10 @@
 #endif
 
 // Binary merklization --- collects motivation from
-// https://github.com/itzmeanjan/blake3/blob/e2a1340a9a7972854889d494b450d72c2198cace/include/merklize.hpp#L4-L12
+// https://github.com/itzmeanjan/blake3/blob/e2a1340/include/merklize.hpp#L4-L12
+//
+// Choice of SHA variant as 2-to-1 hash function is compile-time decision using
+// preprocessor directives, while default choice is SHA2-256
 sycl::cl_ulong
 merklize(sycl::queue& q,
          const sycl::uint* __restrict leaf_nodes,

--- a/include/sha2.hpp
+++ b/include/sha2.hpp
@@ -21,6 +21,13 @@ constexpr sycl::uint K[64] = {
   0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
 };
 
+// Initial hash values, as specified in section 5.3.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr sycl::uint IV_0[8] = {
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+  0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+};
+
 // SHA2 function, defined in section 4.1.2 of Secure Hash Standard
 // http://dx.doi.org/10.6028/NIST.FIPS.180-4
 //

--- a/include/sha2.hpp
+++ b/include/sha2.hpp
@@ -1,0 +1,76 @@
+#pragma once
+#include "utils.hpp"
+#include <CL/sycl.hpp>
+
+namespace sha2 {
+
+// Both of SHA2 {224, 256} -bit variants use same 64 constants, which are
+// specified in section 4.2.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr sycl::uint K[64] = {
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+//
+// Same function is also used in SHA1
+inline sycl::uint
+ch(sycl::uint x, sycl::uint y, sycl::uint z)
+{
+  return (x & y) ^ (~x & z);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+//
+// Same function is also used in SHA1
+inline sycl::uint
+maj(sycl::uint x, sycl::uint y, sycl::uint z)
+{
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+Σ_0(sycl::uint x)
+{
+  return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+Σ_1(sycl::uint x)
+{
+  return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+σ_0(sycl::uint x)
+{
+  return rotr(x, 7) ^ rotr(x, 18) ^ (x >> 3);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+σ_1(sycl::uint x)
+{
+  return rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10);
+}
+
+}

--- a/include/sha2.hpp
+++ b/include/sha2.hpp
@@ -179,4 +179,30 @@ parse_message_words(const sycl::uchar* __restrict in,
   }
 }
 
+// Given 512 -bit input message block, it prepares 64 message schedules
+// for consuming input message into hash state
+//
+// See step 1 of algorithm defined in section 6.2.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+prepare_message_schedule(const sycl::uint* __restrict in,
+                         sycl::uint* const __restrict out)
+{
+  // first 16 message schedules are same as original message words
+  // of 512 -bit message block
+#pragma unroll 16
+  for (size_t i = 0; i < 16; i++) {
+    *(out + i) = *(in + i);
+  }
+
+  // 48 iteration rounds, preparing 48 remaining message schedules
+#pragma unroll 16
+  for (size_t i = 16; i < 64; i++) {
+    const sycl::uint tmp0 = σ_1(*(out + (i - 2))) + *(out + (i - 7));
+    const sycl::uint tmp1 = σ_0(*(out + (i - 15))) + *(out + (i - 16));
+
+    *(out + i) = tmp0 + tmp1;
+  }
+}
+
 }

--- a/include/sha2.hpp
+++ b/include/sha2.hpp
@@ -153,4 +153,23 @@ pad_input_message(const sycl::uint* __restrict in,
   *(out + 31) = 0 | 0b00000010 << 8;
 }
 
+// Each of four consecutive big endian bytes of 1024 -bit padded input are
+// interpreted as SHA2-256 word ( = 32 -bit ), making total of 32 words as
+// output
+//
+// See section 5.2.1 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+parse_message_words(const sycl::uchar* __restrict in,
+                    sycl::uint* const __restrict out)
+{
+  // attempt to partially parallelize this loop execution
+  //
+  // no loop carried dependency !
+#pragma unroll 16
+  for (size_t i = 0; i < 32; i++) {
+    *(out + i) = from_be_bytes_to_words(in + i * 4);
+  }
+}
+
 }

--- a/include/sha2_224.hpp
+++ b/include/sha2_224.hpp
@@ -4,6 +4,18 @@
 
 namespace sha2_224 {
 
+// SHA2-224 specific input/ output width constants, taken from
+// section 1's figure 1 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr size_t IN_LEN_BITS = 448;
+constexpr size_t IN_LEN_BYTES = 56;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+constexpr size_t WORD_SIZE_BITS = 32;
+constexpr size_t WORD_SIZE_BYTES = 4;
+
 // SHA2-224 variant uses 64 words as constants, which are
 // specified in section 4.2.2 of Secure Hash Standard
 // http://dx.doi.org/10.6028/NIST.FIPS.180-4

--- a/include/sha2_224.hpp
+++ b/include/sha2_224.hpp
@@ -1,0 +1,264 @@
+#pragma once
+#include "utils.hpp"
+#include <CL/sycl.hpp>
+
+namespace sha2_224 {
+
+// SHA2-224 variant uses 64 words as constants, which are
+// specified in section 4.2.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr sycl::uint K[64] = {
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+// Initial hash values for SHA2-224, as specified in section 5.3.2 of Secure
+// Hash Standard http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr sycl::uint IV_0[8] = {
+  0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939,
+  0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4
+};
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+//
+// Same function is also used in SHA1
+inline sycl::uint
+ch(sycl::uint x, sycl::uint y, sycl::uint z)
+{
+  return (x & y) ^ (~x & z);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+//
+// Same function is also used in SHA1
+inline sycl::uint
+maj(sycl::uint x, sycl::uint y, sycl::uint z)
+{
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+Σ_0(sycl::uint x)
+{
+  return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+Σ_1(sycl::uint x)
+{
+  return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+σ_0(sycl::uint x)
+{
+  return rotr(x, 7) ^ rotr(x, 18) ^ (x >> 3);
+}
+
+// SHA2 function, defined in section 4.1.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::uint
+σ_1(sycl::uint x)
+{
+  return rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10);
+}
+
+// Given 448 -bits of input ( two SHA2-224 digests concatenated ), this function
+// appends 1 -bit, required 511 -many 0 -bit and finally 64 -bits representing
+// input message length ( = 448 ) in bits, making total of 1024 bits padded
+// input, which will be now parsed into words & hashed.
+//
+// See section 5.1.1 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+pad_input_message(const sycl::uchar* __restrict in,
+                  sycl::uchar* const __restrict out)
+{
+  // copy 448 -bits of original input to output memory allocation
+  //
+  // try to (partially) parallelize this loop execution, due to absense of
+  // loop carried dependencies
+#pragma unroll 8
+  for (size_t i = 0; i < 56; i++) {
+    *(out + i) = *(in + i);
+  }
+
+  constexpr size_t offset = 56;
+
+  // then setting 57 -th byte, as defined in section 5.1.1 of sha2 specification
+  *(out + offset) = 0b10000000;
+
+  // now setting next 69 bytes to zero
+  //
+  // relying on compiler to decide if this loop can be parallelized
+#pragma unroll
+  for (size_t i = 1; i < 70; i++) {
+    *(out + offset + i) = 0;
+  }
+
+  // setting last two bytes of total 128 -bytes output, where
+  // original length of input ( in bits ) is kept
+  //
+  // so last two bytes denote 448 = length of input being hashed
+  *(out + 126) = 0b00000001;
+  *(out + 127) = 0b11000000;
+}
+
+// When input message is interpreted in terms of SHA2-224 words ( = 32 -bit wide
+// ) input padding involves adding 18 new words, which is just same as done in 👆
+// `pad_input_message`, but 4 consecutive big endian bytes are now interpreted
+// as one word
+//
+// Output of this function is 32 -words, where first 14 words are original input
+// ( = 448 bits ) and last 18 words are padding
+//
+// See section 5.1.1 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+pad_input_message(const sycl::uint* __restrict in,
+                  sycl::uint* const __restrict out)
+{
+  // copy first 56 -bytes = 14 words ( sha2-224 words are 32 -bit wide )
+  // from input to output memory allocation
+  //
+  // this loop execution can be fully parallelized
+#pragma unroll 14
+  for (size_t i = 0; i < 14; i++) {
+    *(out + i) = *(in + i);
+  }
+
+  constexpr size_t offset = 14;
+
+  // setting 15 -th word
+  *(out + offset) = 0b10000000 << 24;
+
+  // next 16 words are set to 0, due to padding requirement
+#pragma unroll 16
+  for (size_t i = 1; i < 17; i++) {
+    *(out + offset + i) = 0;
+  }
+
+  // finally last word set to length of input in bits ( = 448 )
+  *(out + 31) = 0 | 0b00000001 << 8 | 0b11000000;
+}
+
+// Given 512 -bit input message block, it prepares 64 message schedules
+// for consuming input message into hash state
+//
+// See step 1 of algorithm defined in section 6.2.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+prepare_message_schedule(const sycl::uint* __restrict in,
+                         sycl::uint* const __restrict out)
+{
+  // first 16 message schedules are same as original message words
+  // of 512 -bit message block
+#pragma unroll 16
+  for (size_t i = 0; i < 16; i++) {
+    *(out + i) = *(in + i);
+  }
+
+  // 48 iteration rounds, preparing 48 remaining message schedules
+#pragma unroll 16
+  for (size_t i = 16; i < 64; i++) {
+    const sycl::uint tmp0 = σ_1(*(out + (i - 2))) + *(out + (i - 7));
+    const sycl::uint tmp1 = σ_0(*(out + (i - 15))) + *(out + (i - 16));
+
+    *(out + i) = tmp0 + tmp1;
+  }
+}
+
+// Takes two padded, parsed input message blocks ( = 1024 -bit ) and computes
+// SHA2-224 digest ( = 224 -bit ) on input in two rounds ( because two message
+// blocks are processed sequentially )
+//
+// See algorithm defined in section 6.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+hash(const sycl::uint* __restrict in, sycl::uint* const __restrict digest)
+{
+  sycl::uint msg_schld[64];
+  sycl::uint hash_state[8];
+
+  // fully parallelize hash state initialization
+#pragma unroll 8
+  for (size_t i = 0; i < 8; i++) {
+    hash_state[i] = IV_0[i];
+  }
+
+  // two message blocks to be processed
+  //
+  // can't unroll this loop, too many logic inside loop body with
+  // somewhat complex nature of loop carried dependencies
+  for (size_t i = 0; i < 2; i++) {
+    // see step 1 of algorithm defined in section  6.2.2 of Secure Hash Standard
+    // http://dx.doi.org/10.6028/NIST.FIPS.180-4
+    prepare_message_schedule(in + 16 * i, msg_schld);
+
+    // see step 2 of algorithm defined in section  6.2.2 of Secure Hash Standard
+    // http://dx.doi.org/10.6028/NIST.FIPS.180-4
+    sycl::uint a = hash_state[0];
+    sycl::uint b = hash_state[1];
+    sycl::uint c = hash_state[2];
+    sycl::uint d = hash_state[3];
+    sycl::uint e = hash_state[4];
+    sycl::uint f = hash_state[5];
+    sycl::uint g = hash_state[6];
+    sycl::uint h = hash_state[7];
+
+    // can't parallelize loop execution, due to complex nature of loop carried
+    // dependencies
+    //
+    // see step 3 of algorithm defined in section  6.2.2 of Secure Hash Standard
+    // http://dx.doi.org/10.6028/NIST.FIPS.180-4
+    for (size_t t = 0; t < 64; t++) {
+      sycl::uint tmp0 = h + Σ_1(e) + ch(e, f, g) + K[t] + msg_schld[t];
+      sycl::uint tmp1 = Σ_0(a) + maj(a, b, c);
+      h = g;
+      g = f;
+      f = e;
+      e = d + tmp0;
+      d = c;
+      c = b;
+      b = a;
+      a = tmp0 + tmp1;
+    }
+
+    // see step 4 of algorithm defined in section  6.2.2 of Secure Hash Standard
+    // http://dx.doi.org/10.6028/NIST.FIPS.180-4
+    hash_state[0] += a;
+    hash_state[1] += b;
+    hash_state[2] += c;
+    hash_state[3] += d;
+    hash_state[4] += e;
+    hash_state[5] += f;
+    hash_state[6] += g;
+    hash_state[7] += h;
+  }
+
+  // write 224 -bit digest back to allocated memory --- final hash state after
+  // consuming two message blocks
+#pragma unroll 7
+  for (size_t i = 0; i < 7; i++) {
+    *(digest + i) = hash_state[i];
+  }
+}
+
+}

--- a/include/sha2_256.hpp
+++ b/include/sha2_256.hpp
@@ -4,7 +4,7 @@
 
 namespace sha2_256 {
 
-// Both of SHA2 {224, 256} -bit variants use same 64 constants, which are
+// SHA2-256 variant uses 64 words as constants, which are
 // specified in section 4.2.2 of Secure Hash Standard
 // http://dx.doi.org/10.6028/NIST.FIPS.180-4
 constexpr sycl::uint K[64] = {
@@ -21,8 +21,8 @@ constexpr sycl::uint K[64] = {
   0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
 };
 
-// Initial hash values, as specified in section 5.3.3 of Secure Hash Standard
-// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+// Initial hash values for SHA2-256, as specified in section 5.3.3 of Secure
+// Hash Standard http://dx.doi.org/10.6028/NIST.FIPS.180-4
 constexpr sycl::uint IV_0[8] = {
   0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
   0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
@@ -114,7 +114,7 @@ pad_input_message(const sycl::uchar* __restrict in,
     *(out + offset + i) = 0;
   }
 
-  // setting last two bytes of total 128 -bytes input, where
+  // setting last two bytes of total 128 -bytes output, where
   // original length of input ( in bits ) is kept
   //
   // so last two bytes denote 512 = length of input being hashed

--- a/include/sha2_256.hpp
+++ b/include/sha2_256.hpp
@@ -4,6 +4,18 @@
 
 namespace sha2_256 {
 
+// SHA2-256 specific input/ output width constants, taken from
+// section 1's figure 1 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr size_t IN_LEN_BITS = 512;
+constexpr size_t IN_LEN_BYTES = 64;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+constexpr size_t WORD_SIZE_BITS = 32;
+constexpr size_t WORD_SIZE_BYTES = 4;
+
 // SHA2-256 variant uses 64 words as constants, which are
 // specified in section 4.2.2 of Secure Hash Standard
 // http://dx.doi.org/10.6028/NIST.FIPS.180-4

--- a/include/sha2_256.hpp
+++ b/include/sha2_256.hpp
@@ -2,7 +2,7 @@
 #include "utils.hpp"
 #include <CL/sycl.hpp>
 
-namespace sha2 {
+namespace sha2_256 {
 
 // Both of SHA2 {224, 256} -bit variants use same 64 constants, which are
 // specified in section 4.2.2 of Secure Hash Standard

--- a/include/test_merklize.hpp
+++ b/include/test_merklize.hpp
@@ -9,35 +9,81 @@ test_merklize(sycl::queue& q)
   // testing on binary merkle tree which has 8 leaf nodes
   constexpr size_t leaf_cnt = 1 << 3;
 
-#if SHA == sha1
+#if defined SHA1
   constexpr size_t i_size = leaf_cnt * sha1::OUT_LEN_BYTES; // in bytes
   constexpr size_t o_size = leaf_cnt * sha1::OUT_LEN_BYTES; // in bytes
-#elif SHA == sha2_224
+#elif defined SHA2_224
   constexpr size_t i_size = leaf_cnt * sha2_224::OUT_LEN_BYTES; // in bytes
   constexpr size_t o_size = leaf_cnt * sha2_224::OUT_LEN_BYTES; // in bytes
-#elif SHA == sha2_256
+#elif defined SHA2_256
   constexpr size_t i_size = leaf_cnt * sha2_256::OUT_LEN_BYTES; // in bytes
   constexpr size_t o_size = leaf_cnt * sha2_256::OUT_LEN_BYTES; // in bytes
 #endif
 
-#if SHA == sha1
   // obtained using following code snippet run on python3 shell
   //
   // >>> import hashlib
+#if defined SHA1
+  //
   // >>> a = [0xff] * 40 # two leaf nodes
   // >>> b = list(hashlib.sha1(bytes(a)).digest()) # = [244, 67, 49, 150, 149,
   // 151, 153, 23, 160, 59, 113, 112, 73, 35, 84, 35, 135, 77, 39, 22]
+
   // >>> c = b * 2
   // >>> d = list(hashlib.sha1(bytes(c)).digest()) # = [7, 7, 30, 157, 84, 109,
   // 232, 147, 213, 85, 108, 21, 251, 107, 125, 35, 100, 216, 165, 28]
+
   // >>> e = d * 2
   // >>> f = list(hashlib.sha1(bytes(e)).digest()) # = [139, 49, 56, 44, 55, 31,
   // 24, 110, 245, 27, 105, 167, 84, 13, 218, 12, 209, 49, 184, 54]
   constexpr sycl::uchar expected[20] = { 139, 49,  56,  44,  55,  31, 24,
                                          110, 245, 27,  105, 167, 84, 13,
                                          218, 12,  209, 49,  184, 54 };
-#elif SHA == sha2_224
-#elif SHA == sha2_256
+#elif defined SHA2_224
+  //
+  // >>> a = [0xff] * 56
+  // >>> b = list(hashlib.sha224(bytes(a)).digest()); b
+  // [140, 250, 128, 28, 254, 116, 112, 113, 88, 113, 102, 5, 189, 54, 5, 27,
+  // 74, 136, 109, 48, 20, 8, 50, 168, 140, 123, 210, 114]
+
+  // >>> c = b * 2
+  // >>> d = list(hashlib.sha224(bytes(c)).digest()); d
+  // [71, 212, 232, 90, 92, 160, 135, 245, 176, 115, 198, 156, 203, 178, 147,
+  // 104, 12, 141, 40, 52, 153, 47, 215, 175, 88, 78, 74, 219]
+
+  // >>> e = d * 2
+  // >>> f = list(hashlib.sha224(bytes(e)).digest())
+
+  // >>> f
+  // [68, 112, 247, 219, 202, 225, 184, 209, 196, 9, 206, 28, 243, 98, 103, 193,
+  // 123, 100, 218, 42, 254, 195, 132, 224, 199, 116, 140, 223]
+
+  constexpr sycl::uchar expected[28] = { 68,  112, 247, 219, 202, 225, 184,
+                                         209, 196, 9,   206, 28,  243, 98,
+                                         103, 193, 123, 100, 218, 42,  254,
+                                         195, 132, 224, 199, 116, 140, 223 };
+#elif defined SHA2_256
+  //
+  // >>> a = [0xff] * 64
+  // >>> b = list(hashlib.sha256(bytes(a)).digest()); b
+  // [134, 103, 231, 24, 41, 78, 158, 13, 241, 211, 6, 0, 186, 62, 235, 32, 31,
+  // 118, 74, 173, 45, 173, 114, 116, 134, 67, 228, 162, 133, 225, 209, 247]
+
+  // >>> c = b * 2
+  // >>> d = list(hashlib.sha256(bytes(c)).digest()); d
+  // [55, 93, 108, 123, 40, 10, 30, 48, 249, 104, 219, 29, 148, 141, 160, 249,
+  // 119, 191, 145, 57, 176, 213, 81, 103, 97, 172, 135, 71, 0, 32, 138, 186]
+
+  // >>> e = d * 2
+  // >>> f = list(hashlib.sha256(bytes(e)).digest())
+
+  // >>> f
+  // [190, 27, 112, 21, 237, 80, 215, 73, 10, 81, 241, 177, 29, 255, 128, 74,
+  // 68, 64, 119, 92, 200, 8, 185, 207, 210, 97, 87, 128, 92, 31, 142, 134]
+  constexpr sycl::uchar expected[32] = {
+    190, 27, 112, 21, 237, 80, 215, 73,  10,  81, 241, 177, 29, 255, 128, 74,
+    68,  64, 119, 92, 200, 8,  185, 207, 210, 97, 87,  128, 92, 31,  142, 134
+  };
 #endif
 
   // acquire resources
@@ -80,11 +126,11 @@ test_merklize(sycl::queue& q)
   // first 20 -bytes should never be touched !
   for (size_t i = 0; i <
 
-#if SHA == sha1
+#if defined SHA1
                      sha1::OUT_LEN_BYTES
-#elif SHA == sha2_224
+#elif defined SHA2_224
                      sha2_224::OUT_LEN_BYTES
-#elif SHA == sha2_256
+#elif defined SHA2_256
                      sha2_256::OUT_LEN_BYTES
 #endif
 
@@ -96,15 +142,15 @@ test_merklize(sycl::queue& q)
 
   // then comes root of merkle tree !
 
-#if SHA == sha1
+#if defined SHA1
   for (size_t i = sha1::OUT_LEN_BYTES, j = 0;
        i < (sha1::OUT_LEN_BYTES << 1) && j < sha1::OUT_LEN_BYTES;
        i++, j++)
-#elif SHA == sha2_224
+#elif defined SHA2_224
   for (size_t i = sha2_224::OUT_LEN_BYTES, j = 0;
        i < (sha2_224::OUT_LEN_BYTES << 1) && j < sha2_224::OUT_LEN_BYTES;
        i++, j++)
-#elif SHA == sha2_256
+#elif defined SHA2_256
   for (size_t i = sha2_256::OUT_LEN_BYTES, j = 0;
        i < (sha2_256::OUT_LEN_BYTES << 1) && j < sha2_256::OUT_LEN_BYTES;
        i++, j++)

--- a/include/test_merklize.hpp
+++ b/include/test_merklize.hpp
@@ -123,7 +123,8 @@ test_merklize(sycl::queue& q)
     const sycl::uint num = *(out_0 + i);
     from_words_to_be_bytes(num, out_1 + (i << 2));
   }
-  // first 20 -bytes should never be touched !
+
+  // first digest should never be touched !
   for (size_t i = 0; i <
 
 #if defined SHA1

--- a/include/test_sha2.hpp
+++ b/include/test_sha2.hpp
@@ -1,0 +1,88 @@
+#pragma once
+#include "sha2.hpp"
+#include <cassert>
+
+void
+test_sha2(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha256(bytes([i for i in range(64)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[32] = { 253, 234, 185, 172, 243, 113, 3,   98,
+                                         189, 38,  88,  205, 201, 162, 158, 143,
+                                         156, 117, 127, 207, 152, 17,  96,  58,
+                                         140, 68,  124, 209, 217, 21,  17,  8 };
+
+  // acquire resources
+  sycl::uchar* in_0 = static_cast<sycl::uchar*>(sycl::malloc_shared(64, q));
+  sycl::uint* in_1 = static_cast<sycl::uint*>(sycl::malloc_shared(64, q));
+  sycl::uchar* out_0 = static_cast<sycl::uchar*>(sycl::malloc_shared(32, q));
+  sycl::uchar* out_1 = static_cast<sycl::uchar*>(sycl::malloc_shared(32, q));
+
+#pragma unroll 16
+  for (size_t i = 0; i < 64; i++) {
+    // preparing input for testing 2-to-1 SHA1 hash
+    *(in_0 + i) = i;
+  }
+
+#pragma unroll 16
+  for (size_t i = 0; i < 16; i++) {
+    sycl::uint v = static_cast<sycl::uint>(i << 2);
+
+    // preparing input to hash function as words, instead of big endian
+    // byte array, which is already prepared above
+    //
+    // so that I can test it both ways --- see below, two kernels dispatched
+    *(in_1 + i) = (v + 0) << 24 | (v + 1) << 16 | (v + 2) << 8 | (v + 3) << 0;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA2_256_v0>([=]() {
+    sycl::uchar padded[128];
+    sycl::uint parsed[32];
+    sycl::uint digest[8];
+
+    sha2::pad_input_message(in_0, padded);
+    sha2::parse_message_words(padded, parsed);
+    sha2::hash(parsed, digest);
+
+    // converting each message word of digest into four consecutive big endian
+    // bytes
+#pragma unroll 8
+    for (size_t i = 0; i < 8; i++) {
+      from_words_to_be_bytes(*(digest + i), out_0 + i * 4);
+    }
+  });
+  q.wait();
+
+  q.single_task<class kernelTestSHA2_256_v1>([=]() {
+    sycl::uint padded[32];
+    sycl::uint digest[8];
+
+    sha2::pad_input_message(in_1, padded);
+    sha2::hash(padded, digest);
+
+    // converting each message word of digest into four consecutive big endian
+    // bytes
+#pragma unroll 8
+    for (size_t i = 0; i < 8; i++) {
+      from_words_to_be_bytes(*(digest + i), out_1 + i * 4);
+    }
+  });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 32; i++) {
+    assert(*(out_0 + i) == expected[i]);
+    assert(*(out_1 + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in_0, q);
+  sycl::free(in_1, q);
+  sycl::free(out_0, q);
+  sycl::free(out_1, q);
+}

--- a/include/test_sha2_224.hpp
+++ b/include/test_sha2_224.hpp
@@ -1,0 +1,95 @@
+#pragma once
+#include "sha2_224.hpp"
+#include <cassert>
+
+void
+test_sha2_224(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha224(bytes([i for i in range(56)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[28] = { 43,  44,  214, 55,  193, 106, 215,
+                                         41,  11,  176, 103, 173, 125, 143,
+                                         208, 78,  32,  79,  164, 58,  132,
+                                         54,  106, 252, 113, 48,  244, 239 };
+
+  // acquire resources
+  sycl::uchar* in_0 = static_cast<sycl::uchar*>(sycl::malloc_shared(56, q));
+  sycl::uint* in_1 = static_cast<sycl::uint*>(sycl::malloc_shared(56, q));
+  sycl::uchar* out_0 = static_cast<sycl::uchar*>(sycl::malloc_shared(28, q));
+  sycl::uchar* out_1 = static_cast<sycl::uchar*>(sycl::malloc_shared(28, q));
+
+#pragma unroll 8
+  for (size_t i = 0; i < 56; i++) {
+    // preparing input for testing 2-to-1 SHA2-224 hash
+    *(in_0 + i) = i;
+  }
+
+#pragma unroll 14
+  for (size_t i = 0; i < 14; i++) {
+    sycl::uint v = static_cast<sycl::uint>(i << 2);
+
+    // preparing input to SHA2-224 hash function as words, instead of big endian
+    // byte array, which is already prepared above
+    //
+    // so that I can test it both ways --- see below, two kernels dispatched
+    *(in_1 + i) = (v + 0) << 24 | (v + 1) << 16 | (v + 2) << 8 | (v + 3) << 0;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA2_224_v0>([=]() {
+    sycl::uchar padded[128];
+    sycl::uint parsed[32];
+    sycl::uint digest[7];
+
+    sha2_224::pad_input_message(in_0, padded);
+
+    // parsing message words such that each of four consecutive
+    // big endian bytes are interpreted as SHA2-224 word ( = 32 -bit )
+#pragma unroll 16
+    for (size_t i = 0; i < 32; i++) {
+      parsed[i] = from_be_bytes_to_words(padded + i * 4);
+    }
+
+    sha2_224::hash(parsed, digest);
+
+    // converting each message word of digest into four consecutive big endian
+    // bytes
+#pragma unroll 7
+    for (size_t i = 0; i < 7; i++) {
+      from_words_to_be_bytes(*(digest + i), out_0 + i * 4);
+    }
+  });
+  q.wait();
+
+  q.single_task<class kernelTestSHA2_224_v1>([=]() {
+    sycl::uint padded[32];
+    sycl::uint digest[7];
+
+    sha2_224::pad_input_message(in_1, padded);
+    sha2_224::hash(padded, digest);
+
+    // converting each message word of digest into four consecutive big endian
+    // bytes
+#pragma unroll 7
+    for (size_t i = 0; i < 7; i++) {
+      from_words_to_be_bytes(*(digest + i), out_1 + i * 4);
+    }
+  });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 28; i++) {
+    assert(*(out_0 + i) == expected[i]);
+    assert(*(out_1 + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in_0, q);
+  sycl::free(in_1, q);
+  sycl::free(out_0, q);
+  sycl::free(out_1, q);
+}

--- a/include/test_sha2_256.hpp
+++ b/include/test_sha2_256.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include "sha2.hpp"
+#include "sha2_256.hpp"
 #include <cassert>
 
 void
-test_sha2(sycl::queue& q)
+test_sha2_256(sycl::queue& q)
 {
   // obtained by executing following snippet in python3 shell
   //
@@ -24,7 +24,7 @@ test_sha2(sycl::queue& q)
 
 #pragma unroll 16
   for (size_t i = 0; i < 64; i++) {
-    // preparing input for testing 2-to-1 SHA1 hash
+    // preparing input for testing 2-to-1 SHA2-256 hash
     *(in_0 + i) = i;
   }
 
@@ -32,7 +32,7 @@ test_sha2(sycl::queue& q)
   for (size_t i = 0; i < 16; i++) {
     sycl::uint v = static_cast<sycl::uint>(i << 2);
 
-    // preparing input to hash function as words, instead of big endian
+    // preparing input to SHA2-256 hash function as words, instead of big endian
     // byte array, which is already prepared above
     //
     // so that I can test it both ways --- see below, two kernels dispatched
@@ -45,9 +45,9 @@ test_sha2(sycl::queue& q)
     sycl::uint parsed[32];
     sycl::uint digest[8];
 
-    sha2::pad_input_message(in_0, padded);
-    sha2::parse_message_words(padded, parsed);
-    sha2::hash(parsed, digest);
+    sha2_256::pad_input_message(in_0, padded);
+    sha2_256::parse_message_words(padded, parsed);
+    sha2_256::hash(parsed, digest);
 
     // converting each message word of digest into four consecutive big endian
     // bytes
@@ -62,8 +62,8 @@ test_sha2(sycl::queue& q)
     sycl::uint padded[32];
     sycl::uint digest[8];
 
-    sha2::pad_input_message(in_1, padded);
-    sha2::hash(padded, digest);
+    sha2_256::pad_input_message(in_1, padded);
+    sha2_256::hash(padded, digest);
 
     // converting each message word of digest into four consecutive big endian
     // bytes

--- a/results/sha1/intel_cpu.md
+++ b/results/sha1/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA1 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha1 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     8.694518 ms                     1.949840 ms                     2.453224 ms
+        2 ^ 21                    17.199786 ms                     4.198702 ms                     4.340316 ms
+        2 ^ 22                    34.146192 ms                     8.113762 ms                     8.214299 ms
+        2 ^ 23                    68.026877 ms                    17.017908 ms                    17.023445 ms
+        2 ^ 24                   135.676135 ms                    33.659895 ms                    33.800263 ms
+        2 ^ 25                   270.682205 ms                    67.579901 ms                    67.553929 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   973.235250 us                     1.393460 ms                     1.373282 ms
+        2 ^ 21                     1.649131 ms                     2.640978 ms                     2.139842 ms
+        2 ^ 22                     2.639893 ms                     4.651534 ms                     3.276608 ms
+        2 ^ 23                     2.983180 ms                     7.928330 ms                     3.842820 ms
+        2 ^ 24                     3.972229 ms                    13.865614 ms                     6.017920 ms
+        2 ^ 25                     5.865988 ms                    19.541160 ms                    10.827998 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.669263 ms                   958.988625 us                   990.652125 us
+        2 ^ 21                     3.128500 ms                     2.164344 ms                     1.608114 ms
+        2 ^ 22                     4.687359 ms                     3.720170 ms                     2.240008 ms
+        2 ^ 23                     6.282229 ms                     7.263596 ms                    11.001944 ms
+        2 ^ 24                    10.525181 ms                    16.860136 ms                     7.371937 ms
+        2 ^ 25                    38.582802 ms                    19.645725 ms                    14.925842 m
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.733615 ms                   814.208625 us                   860.456625 us
+        2 ^ 21                     2.803117 ms                     1.773713 ms                     1.572063 ms
+        2 ^ 22                     4.529533 ms                     3.151578 ms                     2.481437 ms
+        2 ^ 23                     7.846518 ms                     5.298239 ms                     4.982880 ms
+        2 ^ 24                    15.381177 ms                    10.111674 ms                     9.931379 ms
+        2 ^ 25                    30.979469 ms                    19.558067 ms                    19.396226 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.838045 ms                   589.628625 us                   567.175125 us
+        2 ^ 21                     3.318120 ms                     1.128462 ms                     1.144666 ms
+        2 ^ 22                     6.561936 ms                     2.217953 ms                     2.187012 ms
+        2 ^ 23                    13.050308 ms                     4.362224 ms                     4.311594 ms
+        2 ^ 24                    26.043846 ms                     8.694190 ms                     8.636585 ms
+        2 ^ 25                    51.990795 ms                    17.235775 ms                    17.202572 ms
+```

--- a/results/sha1/intel_gpu.md
+++ b/results/sha1/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHA1 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha1 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.540110 ms                     2.075697 ms                     1.384617 ms
+        2 ^ 21                     2.780271 ms                     4.154280 ms                     2.767148 ms
+        2 ^ 22                     5.217264 ms                     8.316750 ms                     5.537688 ms
+        2 ^ 23                    10.041954 ms                    16.615872 ms                    11.068980 ms
+        2 ^ 24                    19.637670 ms                    33.221877 ms                    22.139305 ms
+        2 ^ 25                    38.768184 ms                    66.419808 ms                    44.274379 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     5.891589 ms                   515.056500 us                   458.471250 us
+        2 ^ 21                    11.574329 ms                     1.674400 ms                   932.629500 us
+        2 ^ 22                    22.752375 ms                     3.321722 ms                     1.759496 ms
+        2 ^ 23                    45.262099 ms                     3.524844 ms                     3.527396 ms
+        2 ^ 24                    89.886199 ms                     7.033752 ms                     6.912925 ms
+        2 ^ 25                   179.697573 ms                    13.852368 ms                    13.747352 ms
+```

--- a/results/sha1/nvidia_gpu.md
+++ b/results/sha1/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA1 on Nvidia GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha1 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA1
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   371.222625 us                   735.851625 us                   629.087250 us
+        2 ^ 21                   710.562750 us                     1.451122 ms                     1.256813 ms
+        2 ^ 22                     1.387207 ms                     2.877502 ms                     2.517654 ms
+        2 ^ 23                     2.737060 ms                     5.740448 ms                     5.021942 ms
+        2 ^ 24                     5.438049 ms                    11.454712 ms                    10.039673 ms
+        2 ^ 25                    10.905762 ms                    22.880127 ms                    20.086304 ms
+```

--- a/results/sha2-224/intel_cpu.md
+++ b/results/sha2-224/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA2-224 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_224 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    32.951925 ms                     2.759520 ms                     2.814926 ms
+        2 ^ 21                    64.516266 ms                     5.788733 ms                     5.968292 ms
+        2 ^ 22                   128.407755 ms                    11.307367 ms                    11.437529 ms
+        2 ^ 23                   256.624889 ms                    23.686885 ms                    23.621088 ms
+        2 ^ 24                   513.835194 ms                    47.147656 ms                    46.956709 ms
+        2 ^ 25                      1.028178 s                    93.797258 ms                    93.685513 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.965417 ms                     1.544897 ms                     1.355293 ms
+        2 ^ 21                     3.172233 ms                     3.031929 ms                     3.537930 ms
+        2 ^ 22                     4.156599 ms                     5.563559 ms                     3.975025 ms
+        2 ^ 23                     5.361394 ms                     9.679101 ms                     3.940944 ms
+        2 ^ 24                     6.778410 ms                    16.225821 ms                     6.837070 ms
+        2 ^ 25                    13.008825 ms                    22.569791 ms                    13.593592 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     4.385677 ms                     1.306831 ms                     1.156641 ms
+        2 ^ 21                     6.390041 ms                     2.952304 ms                     1.459918 ms
+        2 ^ 22                     9.426814 ms                     5.543553 ms                     2.713314 ms
+        2 ^ 23                    14.413681 ms                     8.516656 ms                     5.229903 ms
+        2 ^ 24                    27.101954 ms                    14.686123 ms                    20.741114 ms
+        2 ^ 25                    53.921158 ms                    29.347154 ms                    20.799277 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     3.185755 ms                   826.565625 us                   879.207750 us
+        2 ^ 21                     5.637165 ms                     2.280328 ms                     1.707118 ms
+        2 ^ 22                     8.636681 ms                     3.531792 ms                     3.427982 ms
+        2 ^ 23                    14.285976 ms                     7.091349 ms                     7.063932 ms
+        2 ^ 24                    26.902393 ms                    14.187718 ms                    13.970556 ms
+        2 ^ 25                    53.573530 ms                    27.341058 ms                    27.141584 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     6.343735 ms                   793.691250 us                   758.298750 us
+        2 ^ 21                    13.125360 ms                     1.584928 ms                     1.535259 ms
+        2 ^ 22                    23.618047 ms                     3.097280 ms                     3.064426 ms
+        2 ^ 23                    47.116797 ms                     6.069967 ms                     6.034023 ms
+        2 ^ 24                    94.138271 ms                    12.137357 ms                    12.170783 ms
+        2 ^ 25                   188.112406 ms                    24.107783 ms                    24.067320 ms
+```

--- a/results/sha2-224/intel_gpu.md
+++ b/results/sha2-224/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHAS-224 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_224 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     3.299556 ms                     2.910804 ms                     1.937344 ms
+        2 ^ 21                     6.122727 ms                     5.826639 ms                     3.878219 ms
+        2 ^ 22                    11.706552 ms                    11.633836 ms                     7.752127 ms
+        2 ^ 23                    22.779120 ms                    23.257279 ms                    15.497059 ms
+        2 ^ 24                    44.795868 ms                    46.504594 ms                    30.991331 ms
+        2 ^ 25                    88.647936 ms                    92.975571 ms                    61.978897 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    17.515718 ms                     1.176525 ms                   646.715250 us
+        2 ^ 21                    34.412236 ms                     2.338297 ms                     1.263488 ms
+        2 ^ 22                    68.043794 ms                     2.483962 ms                     2.461925 ms
+        2 ^ 23                   135.763826 ms                     4.867016 ms                     4.868448 ms
+        2 ^ 24                   270.338491 ms                     9.695064 ms                     9.765406 ms
+        2 ^ 25                   539.590906 ms                    19.611053 ms                    19.346926 ms
+```

--- a/results/sha2-224/nvidia_gpu.md
+++ b/results/sha2-224/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA2-224 on Nvidia GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_224 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA2-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   704.910000 us                     1.027631 ms                   881.401125 us
+        2 ^ 21                     1.331406 ms                     2.025925 ms                     1.758224 ms
+        2 ^ 22                     2.569016 ms                     4.024841 ms                     3.518417 ms
+        2 ^ 23                     5.039886 ms                     8.027435 ms                     7.029602 ms
+        2 ^ 24                     9.962402 ms                    16.032166 ms                    14.043823 ms
+        2 ^ 25                    19.845703 ms                    32.005005 ms                    28.119873 ms
+```

--- a/results/sha2-256/intel_cpu.md
+++ b/results/sha2-256/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA2-256 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_256 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    31.548119 ms                     3.278957 ms                     3.405930 ms
+        2 ^ 21                    74.383953 ms                     6.448621 ms                     6.583408 ms
+        2 ^ 22                   125.460220 ms                    12.921625 ms                    13.118602 ms
+        2 ^ 23                   251.510298 ms                    27.017091 ms                    26.885037 ms
+        2 ^ 24                   517.607107 ms                    54.093915 ms                    53.885593 ms
+        2 ^ 25                      1.003261 s                   108.179536 ms                   107.411605 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.932850 ms                     1.724421 ms                     1.783388 ms
+        2 ^ 21                     2.873556 ms                     3.809529 ms                     2.683071 ms
+        2 ^ 22                     3.807557 ms                     7.039419 ms                     4.697493 ms
+        2 ^ 23                     3.833782 ms                    12.987659 ms                     4.747487 ms
+        2 ^ 24                     7.031215 ms                    17.484357 ms                     8.856618 ms
+        2 ^ 25                    13.411188 ms                    26.905162 ms                    17.626729 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     4.279716 ms                     1.507160 ms                     1.260632 ms
+        2 ^ 21                     6.346261 ms                     3.351768 ms                     1.676602 ms
+        2 ^ 22                     9.212702 ms                     5.802055 ms                     2.976046 ms
+        2 ^ 23                    14.617657 ms                     9.280188 ms                     5.821066 ms
+        2 ^ 24                    46.915648 ms                    15.775025 ms                    11.660212 ms
+        2 ^ 25                    55.808860 ms                    27.940748 ms                    23.630878 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     3.345548 ms                     1.012641 ms                     1.034661 ms
+        2 ^ 21                     6.304066 ms                     2.055579 ms                     1.951553 ms
+        2 ^ 22                     9.097706 ms                     4.116220 ms                     3.959602 ms
+        2 ^ 23                    14.797761 ms                     8.225529 ms                     7.940669 ms
+        2 ^ 24                    28.128955 ms                    16.154102 ms                    16.046252 ms
+        2 ^ 25                    56.248897 ms                    31.414169 ms                    31.100541 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     5.964265 ms                   916.032750 us                   880.749375 us
+        2 ^ 21                    11.833022 ms                     1.835574 ms                     1.758230 ms
+        2 ^ 22                    23.575996 ms                     3.509018 ms                     3.454184 ms
+        2 ^ 23                    46.975276 ms                     6.929970 ms                     6.879241 ms
+        2 ^ 24                    93.821823 ms                    13.806551 ms                    13.762214 ms
+        2 ^ 25                   187.466457 ms                    38.789720 ms                    27.488194 ms
+```

--- a/results/sha2-256/intel_gpu.md
+++ b/results/sha2-256/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHA2-256 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_256 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     4.661943 ms                     3.329839 ms                     2.217833 ms
+        2 ^ 21                     9.002214 ms                     6.644352 ms                     4.428859 ms
+        2 ^ 22                    17.619459 ms                    13.286383 ms                     8.860488 ms
+        2 ^ 23                    34.812453 ms                    26.583785 ms                    17.713059 ms
+        2 ^ 24                    69.134013 ms                    53.142063 ms                    35.421653 ms
+        2 ^ 25                   137.558889 ms                   106.253335 ms                    70.831332 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    18.288241 ms                     1.332399 ms                   814.728000 us
+        2 ^ 21                    36.194453 ms                     1.485098 ms                     1.440838 ms
+        2 ^ 22                    72.090231 ms                     2.873336 ms                     2.841028 ms
+        2 ^ 23                   144.270973 ms                     5.664750 ms                     5.593536 ms
+        2 ^ 24                   287.842319 ms                    11.170638 ms                    11.055911 ms
+        2 ^ 25                   574.907261 ms                    22.107091 ms                    22.232961 ms
+```

--- a/results/sha2-256/nvidia_gpu.md
+++ b/results/sha2-256/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA2-256 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha2_256 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA2-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   719.621625 us                     1.169785 ms                     1.005707 ms
+        2 ^ 21                     1.340929 ms                     2.312210 ms                     2.009216 ms
+        2 ^ 22                     2.567003 ms                     4.590637 ms                     4.015045 ms
+        2 ^ 23                     5.018921 ms                     9.169464 ms                     8.026062 ms
+        2 ^ 24                     9.837526 ms                    18.313293 ms                    16.052857 ms
+        2 ^ 25                    19.494141 ms                    36.597290 ms                    32.106445 ms
+```

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,6 @@
 #include "test_merklize.hpp"
 #include "test_sha1.hpp"
+#include "test_sha2_224.hpp"
 #include "test_sha2_256.hpp"
 #include <iostream>
 
@@ -23,6 +24,9 @@ main(int argc, char** argv)
 
   test_sha2_256(q);
   std::cout << "passed SHA2-256 test !" << std::endl;
+
+  test_sha2_224(q);
+  std::cout << "passed SHA2-224 test !" << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,6 @@
 #include "test_merklize.hpp"
 #include "test_sha1.hpp"
+#include "test_sha2_256.hpp"
 #include <iostream>
 
 int
@@ -19,6 +20,9 @@ main(int argc, char** argv)
   std::cout << "passed SHA1 test !" << std::endl;
   test_merklize(q);
   std::cout << "passed binary merklization ( using SHA1 ) test !" << std::endl;
+
+  test_sha2_256(q);
+  std::cout << "passed SHA2-256 test !" << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -19,14 +19,24 @@ main(int argc, char** argv)
 
   test_sha1(q);
   std::cout << "passed SHA1 test !" << std::endl;
-  test_merklize(q);
-  std::cout << "passed binary merklization ( using SHA1 ) test !" << std::endl;
+
+  test_sha2_224(q);
+  std::cout << "passed SHA2-224 test !" << std::endl;
 
   test_sha2_256(q);
   std::cout << "passed SHA2-256 test !" << std::endl;
 
-  test_sha2_224(q);
-  std::cout << "passed SHA2-224 test !" << std::endl;
+  test_merklize(q);
+
+#if defined SHA1
+  std::cout << "passed binary merklization ( using SHA1 ) test !" << std::endl;
+#elif defined SHA2_224
+  std::cout << "passed binary merklization ( using SHA2-224 ) test !"
+            << std::endl;
+#elif defined SHA2_256
+  std::cout << "passed binary merklization ( using SHA2-256 ) test !"
+            << std::endl;
+#endif
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I'm following https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf for implementing 2-to-1 SHA2-256 hash function in SYCL, so that I can make use of it for constructing Binary Merkle Tree. 

> 2-to-1 hash : Two SHA2-256 digests are hashed to produce one SHA2-256 digest. 

I've already implementing SHA1 from above linked specification. [ **May be not of that much interest these days, due to [this](https://csrc.nist.gov/Projects/Hash-Functions/NIST-Policy-on-Hash-Functions)** ]