### PR TITLE
Implementing SHA2-384 --- 2-to-1 Hash and Binary Merklization

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,14 @@ InstalledDir: /home/ubuntu/sycl_workspace/llvm/build/bin
 
 If you happen to be interested in 2-to-1 hash implementation of
 
-- [SHA1](https://github.com/itzmeanjan/merklize-sha/blob/c0a8c0155b5bed04a7693b815d257acb68effcb8/example/sha1.cpp)
-- [SHA2-224](https://github.com/itzmeanjan/merklize-sha/blob/c03e42c0502a9d8104609c9f64033afbf6eac81a/example/sha2_224.cpp)
-- [SHA2-256](https://github.com/itzmeanjan/merklize-sha/blob/c03e42c0502a9d8104609c9f64033afbf6eac81a/example/sha2_256.cpp)
+- [SHA1](https://github.com/itzmeanjan/merklize-sha/blob/8f711fc/example/sha1.cpp)
+- [SHA2-224](https://github.com/itzmeanjan/merklize-sha/blob/8f711fc/example/sha2_224.cpp)
+- [SHA2-256](https://github.com/itzmeanjan/merklize-sha/blob/8f711fc/example/sha2_256.cpp)
+- [SHA2-384](https://github.com/itzmeanjan/merklize-sha/blob/8f711fc/example/sha2_384.cpp)
 
 where two digests of respective hash functions are input, in byte concatenated form, to `hash( ... )` function, consider taking a look at above hyperlinked examples.
 
-You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/f2eb91733e193de9913e7cb9622c199b77534fcc/include/merklize.hpp)
+You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/8f711fc/include/merklize.hpp)
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ I've accompanied each hash function implementation along with binary merklizatio
 SHA=sha1 make; make clean
 SHA=sha2_224 make; make clean
 SHA=sha2_256 make; make clean
+SHA=sha2_384 make; make clean
 ```
 
 ## Benchmarks
@@ -111,5 +112,9 @@ I'm keeping binary merklization benchmark results of
   - [Nvidia GPU(s)](results/sha2-256/nvidia_gpu.md)
   - [Intel CPU(s)](results/sha2-256/intel_cpu.md)
   - [Intel GPU(s)](results/sha2-256/intel_gpu.md)
+- SHA2-384
+  - [Nvidia GPU(s)](results/sha2-384/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha2-384/intel_cpu.md)
+  - [Intel GPU(s)](results/sha2-384/intel_gpu.md)
 
 obtained after executing them on multiple accelerators.

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -47,6 +47,9 @@ main(int argc, char** argv)
 #elif defined SHA2_256
   std::cout << "\nBenchmarking Binary Merklization using SHA2-256" << std::endl
             << std::endl;
+#elif defined SHA2_384
+  std::cout << "\nBenchmarking Binary Merklization using SHA2-384" << std::endl
+            << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/example/sha2_224.cpp
+++ b/example/sha2_224.cpp
@@ -58,7 +58,7 @@ main(int argc, char** argv)
     // parse message blocks into words
 #pragma unroll 16
     for (size_t i = 0; i < 32; i++) {
-      parsed[i] = from_be_bytes_to_words(padded + i * 4);
+      parsed[i] = from_be_bytes_to_u32_words(padded + i * 4);
     }
 
     // now compute SHA2-224 on input words

--- a/example/sha2_256.cpp
+++ b/example/sha2_256.cpp
@@ -61,7 +61,7 @@ main(int argc, char** argv)
     // parse message blocks into words
 #pragma unroll 16
     for (size_t i = 0; i < 32; i++) {
-      parsed[i] = from_be_bytes_to_words(padded + i * 4);
+      parsed[i] = from_be_bytes_to_u32_words(padded + i * 4);
     }
 
     // now compute SHA2-256 on input words

--- a/example/sha2_384.cpp
+++ b/example/sha2_384.cpp
@@ -1,0 +1,93 @@
+#include "sha2_384.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA2-384 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 48
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[48] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 48
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[48] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha384(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[48] = {
+    120, 195, 4,   101, 32,  184, 165, 150, 9,   221, 16,  126,
+    43,  186, 64,  107, 143, 124, 119, 179, 53,  135, 31,  39,
+    146, 115, 75,  158, 151, 254, 247, 182, 91,  31,  17,  212,
+    123, 219, 246, 75,  217, 24,  111, 77,  215, 195, 125, 165
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  q.single_task<class kernelExampleSHA2_384>([=]() {
+    sycl::uchar padded[128];
+    sycl::ulong parsed[16];
+    sycl::ulong digest[6];
+
+    // pad input so that it's two full message blocks
+    sha2_384::pad_input_message(in, padded);
+
+    // parse message blocks into words
+#pragma unroll 8
+    for (size_t i = 0; i < 16; i++) {
+      parsed[i] = from_be_bytes_to_u64_words(padded + (i << 3));
+    }
+
+    // now compute SHA2-384 on input words
+    sha2_384::hash(parsed, digest);
+
+    // convert SHA2-384 digest words to big endian bytes
+#pragma unroll 6
+    for (size_t i = 0; i < 6; i++) {
+      from_words_to_be_bytes(*(digest + i), out + (i << 3));
+    }
+  });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/include/sha1.hpp
+++ b/include/sha1.hpp
@@ -167,7 +167,7 @@ parse_message_words(const sycl::uchar* __restrict in,
   // no loop carried dependency !
 #pragma unroll 16
   for (size_t i = 0; i < 16; i++) {
-    *(out + i) = from_be_bytes_to_words(in + i * 4);
+    *(out + i) = from_be_bytes_to_u32_words(in + i * 4);
   }
 }
 

--- a/include/sha2_256.hpp
+++ b/include/sha2_256.hpp
@@ -187,7 +187,7 @@ parse_message_words(const sycl::uchar* __restrict in,
   // no loop carried dependency !
 #pragma unroll 16
   for (size_t i = 0; i < 32; i++) {
-    *(out + i) = from_be_bytes_to_words(in + i * 4);
+    *(out + i) = from_be_bytes_to_u32_words(in + i * 4);
   }
 }
 

--- a/include/sha2_384.hpp
+++ b/include/sha2_384.hpp
@@ -4,6 +4,18 @@
 
 namespace sha2_384 {
 
+// SHA2-384 specific input/ output width constants, taken from
+// section 1's figure 1 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr size_t IN_LEN_BITS = 768;
+constexpr size_t IN_LEN_BYTES = 96;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+constexpr size_t WORD_SIZE_BITS = 64;
+constexpr size_t WORD_SIZE_BYTES = 8;
+
 // SHA2-{384, 512, 512/ 224, 512/ 256} constants
 //
 // See section 4.2.3 of Secure Hash Standard

--- a/include/sha2_384.hpp
+++ b/include/sha2_384.hpp
@@ -1,0 +1,73 @@
+#pragma once
+#include "utils.hpp"
+#include <CL/sycl.hpp>
+
+namespace sha2_384 {
+
+// SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
+// variants
+//
+// See section 4.1.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+ch(sycl::ulong x, sycl::ulong y, sycl::ulong z)
+{
+  return (x & y) ^ (~x & z);
+}
+
+// SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
+// variants
+//
+// See section 4.1.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+maj(sycl::ulong x, sycl::ulong y, sycl::ulong z)
+{
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+// SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
+// variants
+//
+// See section 4.1.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+Σ_0(sycl::ulong x)
+{
+  return rotr(x, 28) ^ rotr(x, 34) ^ rotr(x, 39);
+}
+
+// SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
+// variants
+//
+// See section 4.1.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+Σ_1(sycl::ulong x)
+{
+  return rotr(x, 14) ^ rotr(x, 18) ^ rotr(x, 41);
+}
+
+// SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
+// variants
+//
+// See section 4.1.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+σ_0(sycl::ulong x)
+{
+  return rotr(x, 1) ^ rotr(x, 8) ^ (x >> 7);
+}
+
+// SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
+// variants
+//
+// See section 4.1.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+σ_1(sycl::ulong x)
+{
+  return rotr(x, 19) ^ rotr(x, 61) ^ (x >> 6);
+}
+
+}

--- a/include/sha2_384.hpp
+++ b/include/sha2_384.hpp
@@ -185,4 +185,27 @@ pad_input_message(const sycl::ulong* __restrict in,
   *(out + 15) = 0ul | 0b00000011ul << 8;
 }
 
+// From sixteen message words in a mesage block, prepares message
+// schedule of 80 message words, for mixing into hash state
+//
+// See step 1 of algorithm defined in section 6.4.2 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+void
+prepare_message_schedule(const sycl::ulong* __restrict in,
+                         sycl::ulong* const __restrict out)
+{
+#pragma unroll 8
+  for (size_t i = 0; i < 16; i++) {
+    *(out + i) = *(in + i);
+  }
+
+#pragma unroll 8
+  for (size_t i = 16; i < 80; i++) {
+    const sycl::ulong tmp0 = σ_1(*(out + (i - 2))) + *(out + (i - 7));
+    const sycl::ulong tmp1 = σ_0(*(out + (i - 15))) + *(out + (i - 16));
+
+    *(out + i) = tmp0 + tmp1;
+  }
+}
+
 }

--- a/include/sha2_384.hpp
+++ b/include/sha2_384.hpp
@@ -4,6 +4,49 @@
 
 namespace sha2_384 {
 
+// SHA2-{384, 512, 512/ 224, 512/ 256} constants
+//
+// See section 4.2.3 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr sycl::ulong K[80] = {
+  0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f,
+  0xe9b5dba58189dbbc, 0x3956c25bf348b538, 0x59f111f1b605d019,
+  0x923f82a4af194f9b, 0xab1c5ed5da6d8118, 0xd807aa98a3030242,
+  0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+  0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235,
+  0xc19bf174cf692694, 0xe49b69c19ef14ad2, 0xefbe4786384f25e3,
+  0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65, 0x2de92c6f592b0275,
+  0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+  0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f,
+  0xbf597fc7beef0ee4, 0xc6e00bf33da88fc2, 0xd5a79147930aa725,
+  0x06ca6351e003826f, 0x142929670a0e6e70, 0x27b70a8546d22ffc,
+  0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+  0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6,
+  0x92722c851482353b, 0xa2bfe8a14cf10364, 0xa81a664bbc423001,
+  0xc24b8b70d0f89791, 0xc76c51a30654be30, 0xd192e819d6ef5218,
+  0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+  0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99,
+  0x34b0bcb5e19b48a8, 0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb,
+  0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3, 0x748f82ee5defb2fc,
+  0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+  0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915,
+  0xc67178f2e372532b, 0xca273eceea26619c, 0xd186b8c721c0c207,
+  0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178, 0x06f067aa72176fba,
+  0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+  0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc,
+  0x431d67c49c100d4c, 0x4cc5d4becb3e42b6, 0x597f299cfc657e2a,
+  0x5fcb6fab3ad6faec, 0x6c44198c4a475817
+};
+
+// SHA2-384 -bit variant's initial hash state values
+//
+// Taken from section 5.3.4 of Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+constexpr sycl::ulong IV_0[8] = { 0xcbbb9d5dc1059ed8, 0x629a292a367cd507,
+                                  0x9159015a3070dd17, 0x152fecd8f70e5939,
+                                  0x67332667ffc00b31, 0x8eb44a8768581511,
+                                  0xdb0c2e0d64f98fa7, 0x47b5481dbefa4fa4 };
+
 // SHA2 function, used for 384 -bit, 512 -bit, 512/ 224 -bit and 512/ 256 -bit
 // variants
 //

--- a/include/test_merklize.hpp
+++ b/include/test_merklize.hpp
@@ -109,7 +109,7 @@ test_merklize(sycl::queue& q)
   // I'm thinking correctly !
 #pragma unroll 8
   for (size_t i = 0; i < (i_size >> 2); i++) {
-    *(in_1 + i) = from_be_bytes_to_words(in_0 + i * 4);
+    *(in_1 + i) = from_be_bytes_to_u32_words(in_0 + i * 4);
   }
 
   // wait until completely merklized !

--- a/include/test_sha2_224.hpp
+++ b/include/test_sha2_224.hpp
@@ -51,7 +51,7 @@ test_sha2_224(sycl::queue& q)
     // big endian bytes are interpreted as SHA2-224 word ( = 32 -bit )
 #pragma unroll 16
     for (size_t i = 0; i < 32; i++) {
-      parsed[i] = from_be_bytes_to_words(padded + i * 4);
+      parsed[i] = from_be_bytes_to_u32_words(padded + i * 4);
     }
 
     sha2_224::hash(parsed, digest);

--- a/include/test_sha2_384.hpp
+++ b/include/test_sha2_384.hpp
@@ -1,0 +1,97 @@
+#pragma once
+#include "sha2_384.hpp"
+#include <cassert>
+
+void
+test_sha2_384(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha384(bytes([i for i in range(96)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loops
+  constexpr sycl::uchar expected[48] = {
+    230, 6,   0,   78,  205, 198, 135, 139, 94,  193, 95,  69,
+    84,  1,   124, 207, 150, 46,  146, 204, 110, 174, 190, 73,
+    151, 186, 52,  236, 14,  83,  198, 125, 86,  76,  132, 97,
+    192, 19,  112, 26,  64,  31,  227, 71,  236, 15,  114, 30
+  };
+
+  // acquire resources
+  sycl::uchar* in_0 = static_cast<sycl::uchar*>(sycl::malloc_shared(96, q));
+  sycl::ulong* in_1 = static_cast<sycl::ulong*>(sycl::malloc_shared(96, q));
+  sycl::uchar* out_0 = static_cast<sycl::uchar*>(sycl::malloc_shared(48, q));
+  sycl::uchar* out_1 = static_cast<sycl::uchar*>(sycl::malloc_shared(48, q));
+
+#pragma unroll 16
+  for (size_t i = 0; i < 96; i++) {
+    // preparing input for testing 2-to-1 SHA2-384 hash
+    *(in_0 + i) = i;
+  }
+
+#pragma unroll 12
+  for (size_t i = 0; i < 12; i++) {
+    sycl::ulong v = static_cast<sycl::ulong>(i << 3);
+
+    // preparing input to SHA2-384 hash function as words, instead of big endian
+    // byte array, which is already prepared above
+    //
+    // so that I can test it both ways --- see below, two kernels dispatched
+    *(in_1 + i) = (v + 0) << 56 | (v + 1) << 48 | (v + 2) << 40 |
+                  (v + 3) << 32 | (v + 4) << 24 | (v + 5) << 16 | (v + 6) << 8 |
+                  (v + 7) << 0;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA2_384_v0>([=]() {
+    sycl::uchar padded[128];
+    sycl::ulong parsed[16];
+    sycl::ulong digest[6];
+
+    sha2_384::pad_input_message(in_0, padded);
+
+#pragma unroll 8
+    for (size_t i = 0; i < 16; i++) {
+      parsed[i] = from_be_bytes_to_u64_words(padded + (i << 3));
+    }
+
+    sha2_384::hash(parsed, digest);
+
+    // converting each message word of digest into eight consecutive big endian
+    // bytes, making total 48 -bytes SHA2-384 digest
+#pragma unroll 6
+    for (size_t i = 0; i < 6; i++) {
+      from_words_to_be_bytes(*(digest + i), out_0 + (i << 3));
+    }
+  });
+  q.wait();
+
+  q.single_task<class kernelTestSHA2_384_v1>([=]() {
+    sycl::ulong padded[16];
+    sycl::ulong digest[6];
+
+    sha2_384::pad_input_message(in_1, padded);
+    sha2_384::hash(padded, digest);
+
+    // converting each message word of digest into eight consecutive big endian
+    // bytes, making total 48 -bytes SHA2-384 digest
+#pragma unroll 6
+    for (size_t i = 0; i < 6; i++) {
+      from_words_to_be_bytes(*(digest + i), out_1 + (i << 3));
+    }
+  });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 48; i++) {
+    assert(*(out_0 + i) == expected[i]);
+    assert(*(out_1 + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in_0, q);
+  sycl::free(in_1, q);
+  sycl::free(out_0, q);
+  sycl::free(out_1, q);
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -73,7 +73,7 @@ time_event(sycl::event& evt)
 // This function can be used for converting four contiguous big endian bytes
 // into 32 -bit word
 inline sycl::uint
-from_be_bytes_to_words(const sycl::uchar* in)
+from_be_bytes_to_u32_words(const sycl::uchar* in)
 {
   return (static_cast<sycl::uint>(*(in + 0)) << 24) |
          (static_cast<sycl::uint>(*(in + 1)) << 16) |

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -13,6 +13,21 @@ rotr(sycl::uint x, size_t n)
   return (x >> n) | (x << (32 - n));
 }
 
+// Circular right shift of 64 -bit SHA2 word, by n bit places
+//
+// Ensure that n < 64
+//
+// Pretty much same as above definition, just works
+// with different word size ( = 64 bit )
+//
+// See section 3.2's point 4 in Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+rotr(sycl::ulong x, size_t n)
+{
+  return (x >> n) | (x << (64 - n));
+}
+
 // Circular left shift of 32 -bit word, by n bit places
 //
 // Make sure n < 32
@@ -23,6 +38,21 @@ inline sycl::uint
 rotl(sycl::uint x, size_t n)
 {
   return (x << n) | (x >> (32 - n));
+}
+
+// Circular left shift of 64 -bit SHA2 word, by n bit places
+//
+// Ensure that n < 64
+//
+// Pretty much same as above definition, just works
+// with different word size ( = 64 bit )
+//
+// See section 3.2's point 4 in Secure Hash Standard
+// http://dx.doi.org/10.6028/NIST.FIPS.180-4
+inline sycl::ulong
+rotl(sycl::ulong x, size_t n)
+{
+  return (x << n) | (x >> (64 - n));
 }
 
 // Profile execution time of some command, whose submission resulted into

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -81,6 +81,20 @@ from_be_bytes_to_words(const sycl::uchar* in)
          (static_cast<sycl::uint>(*(in + 3)) << 0);
 }
 
+// Used for converting eight consecutive big endian bytes to 64 -bit word
+inline sycl::ulong
+from_be_bytes_to_u64_words(const sycl::uchar* in)
+{
+  return (static_cast<sycl::ulong>(*(in + 0)) << 56) |
+         (static_cast<sycl::ulong>(*(in + 1)) << 48) |
+         (static_cast<sycl::ulong>(*(in + 2)) << 40) |
+         (static_cast<sycl::ulong>(*(in + 3)) << 32) |
+         (static_cast<sycl::ulong>(*(in + 4)) << 24) |
+         (static_cast<sycl::ulong>(*(in + 5)) << 16) |
+         (static_cast<sycl::ulong>(*(in + 6)) << 8) |
+         (static_cast<sycl::ulong>(*(in + 7)) << 0);
+}
+
 // This function can be used for converting 32 -bit word to four
 // consecutive big endian bytes
 inline void
@@ -90,4 +104,18 @@ from_words_to_be_bytes(const sycl::uint word, sycl::uchar* const out)
   *(out + 1) = static_cast<sycl::uchar>((word >> 16) & 0xff);
   *(out + 2) = static_cast<sycl::uchar>((word >> 8) & 0xff);
   *(out + 3) = static_cast<sycl::uchar>((word >> 0) & 0xff);
+}
+
+// Used for converting one 64 -bit word to, eight consecutive big endian bytes
+inline void
+from_words_to_be_bytes(const sycl::ulong word, sycl::uchar* const out)
+{
+  *(out + 0) = static_cast<sycl::uchar>((word >> 56) & 0xff);
+  *(out + 1) = static_cast<sycl::uchar>((word >> 48) & 0xff);
+  *(out + 2) = static_cast<sycl::uchar>((word >> 40) & 0xff);
+  *(out + 3) = static_cast<sycl::uchar>((word >> 32) & 0xff);
+  *(out + 4) = static_cast<sycl::uchar>((word >> 24) & 0xff);
+  *(out + 5) = static_cast<sycl::uchar>((word >> 16) & 0xff);
+  *(out + 6) = static_cast<sycl::uchar>((word >> 8) & 0xff);
+  *(out + 7) = static_cast<sycl::uchar>((word >> 0) & 0xff);
 }

--- a/results/sha2-384/intel_cpu.md
+++ b/results/sha2-384/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA2-384 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_384 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    34.178252 ms                     5.218289 ms                     5.176465 ms
+        2 ^ 21                    67.694605 ms                     9.876354 ms                     9.956149 ms
+        2 ^ 22                   135.818527 ms                    20.974393 ms                    20.623947 ms
+        2 ^ 23                   269.923540 ms                    41.135928 ms                    41.253850 ms
+        2 ^ 24                   539.628880 ms                    81.100490 ms                    81.234604 ms
+        2 ^ 25                      1.076815 s                   162.093054 ms                   170.061430 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     2.041907 ms                     2.473095 ms                     2.159533 ms
+        2 ^ 21                     2.939270 ms                     5.150314 ms                     3.615391 ms
+        2 ^ 22                     3.365169 ms                     8.887749 ms                     3.851239 ms
+        2 ^ 23                     4.071329 ms                    14.324398 ms                     6.099382 ms
+        2 ^ 24                     7.771932 ms                    20.828297 ms                    11.840717 ms
+        2 ^ 25                    15.053307 ms                    32.482493 ms                    23.908711 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     4.064986 ms                     2.310313 ms                     1.988848 ms
+        2 ^ 21                     5.825557 ms                     5.045159 ms                     2.566375 ms
+        2 ^ 22                     8.369808 ms                     7.572489 ms                     4.657053 ms
+        2 ^ 23                    14.607859 ms                    13.775337 ms                     9.238311 ms
+        2 ^ 24                    29.402728 ms                    22.677070 ms                    18.767093 ms
+        2 ^ 25                    58.258111 ms                    50.695223 ms                    37.394962 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     3.254170 ms                     1.595552 ms                     1.494076 ms
+        2 ^ 21                     6.101297 ms                     3.465971 ms                     3.164907 ms
+        2 ^ 22                     9.464844 ms                     6.263030 ms                     6.078313 ms
+        2 ^ 23                    17.985553 ms                    12.084928 ms                    11.970836 ms
+        2 ^ 24                    35.754916 ms                    24.186201 ms                    24.326572 ms
+        2 ^ 25                    71.200293 ms                    47.340005 ms                    46.669111 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     9.374931 ms                     1.534824 ms                     1.399091 ms
+        2 ^ 21                    12.748752 ms                     2.719041 ms                     2.688041 ms
+        2 ^ 22                    25.307536 ms                     5.312269 ms                     5.241426 ms
+        2 ^ 23                    50.210153 ms                    11.913176 ms                    10.421805 ms
+        2 ^ 24                   100.164710 ms                    20.851078 ms                    20.712672 ms
+        2 ^ 25                   201.872463 ms                    41.370812 ms                    41.488984 m
+```

--- a/results/sha2-384/intel_gpu.md
+++ b/results/sha2-384/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHA2-384 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha2_384 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     4.427943 ms                     4.985896 ms                     3.320733 ms
+        2 ^ 21                     8.178846 ms                     9.974016 ms                     6.650143 ms
+        2 ^ 22                    15.558582 ms                    19.935025 ms                    13.285408 ms
+        2 ^ 23                    30.297657 ms                    39.871942 ms                    26.567385 ms
+        2 ^ 24                    59.669610 ms                    79.701707 ms                    53.124454 ms
+        2 ^ 25                   118.088451 ms                   159.366987 ms                   106.247778 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    35.474719 ms                     1.999283 ms                     2.027918 ms
+        2 ^ 21                    70.131535 ms                     3.979767 ms                     3.991096 ms
+        2 ^ 22                   139.684518 ms                     7.969120 ms                     7.980388 ms
+        2 ^ 23                   278.812085 ms                    15.334540 ms                    15.672994 ms
+        2 ^ 24                   555.954314 ms                    29.387789 ms                    29.410822 ms
+        2 ^ 25                      1.112163 s                    48.478432 ms                    47.542255 ms
+```

--- a/results/sha2-384/nvidia_gpu.md
+++ b/results/sha2-384/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA2-384 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha2_384 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA2-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   982.126125 us                     1.744032 ms                     1.507438 ms
+        2 ^ 21                     1.833298 ms                     3.457054 ms                     3.012680 ms
+        2 ^ 22                     3.523499 ms                     6.881653 ms                     6.020691 ms
+        2 ^ 23                     6.842102 ms                    13.744263 ms                    12.048889 ms
+        2 ^ 24                    13.480591 ms                    27.436157 ms                    24.112793 ms
+        2 ^ 25                    26.730469 ms                    54.882568 ms                    48.191162 ms
+```

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -2,6 +2,7 @@
 #include "test_sha1.hpp"
 #include "test_sha2_224.hpp"
 #include "test_sha2_256.hpp"
+#include "test_sha2_384.hpp"
 #include <iostream>
 
 int
@@ -18,13 +19,16 @@ main(int argc, char** argv)
             << std::endl;
 
   test_sha1(q);
-  std::cout << "passed SHA1 test !" << std::endl;
+  std::cout << "passed SHA1     test !" << std::endl;
 
   test_sha2_224(q);
   std::cout << "passed SHA2-224 test !" << std::endl;
 
   test_sha2_256(q);
   std::cout << "passed SHA2-256 test !" << std::endl;
+
+  test_sha2_384(q);
+  std::cout << "passed SHA2-384 test !" << std::endl;
 
   test_merklize(q);
 


### PR DESCRIPTION
- 2-to-1 hash function using SHA2 family's 384 -bit variant
- Extend generic binary merklization implementation to also work with SHA2-384
