### PR TITLE
Implementing SHA3-256 based Binary Merklization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SYCL accelerated Binary Merklization using SHA1, SHA2 & SHA3
 
 ## Motivation
 
-After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 families of cryptographic hash functions are data parallel, requiring to process each message block ( can be 512 -bit/ 1024 -bit ) sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2 families of cryptographic ( 2-to-1 ) hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
+After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 & SHA3 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 & SHA3 families of cryptographic hash functions are data parallel, requiring to process each message block ( can be 512 -bit/ 1024 -bit ) sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2/ SHA3 families of cryptographic ( 2-to-1 ) hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
 
 ```bash
   ((a, b), (c, d))          < --- [Level 1] [Root]
@@ -32,7 +32,9 @@ If you happen to be interested in Binary Merklization using Rescue Prime Hash/ B
 - [Binary Merklization using Rescue Prime Hash](https://github.com/itzmeanjan/ff-gpu)
 - [Binary Merklization using BLAKE3](https://github.com/itzmeanjan/blake3)
 
-> During SHA1, SHA2 implementations, I've followed Secure Hash Standard [specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf).
+> During SHA1, SHA2 implementations, I've followed Secure Hash Standard [specification](http://dx.doi.org/10.6028/NIST.FIPS.180-4).
+
+> During SHA3 implementations, I've followed SHA-3 Standard [specification](http://dx.doi.org/10.6028/NIST.FIPS.202).
 
 > Using SHA1 for binary merklization may not be a good choice these days, see [here](https://csrc.nist.gov/Projects/Hash-Functions/NIST-Policy-on-Hash-Functions). But still I'm keeping SHA1 implementation, just as a reference.
 
@@ -131,5 +133,9 @@ I'm keeping binary merklization benchmark results of
   - [Nvidia GPU(s)](results/sha2-512-256/nvidia_gpu.md)
   - [Intel CPU(s)](results/sha2-512-256/intel_cpu.md)
   - [Intel GPU(s)](results/sha2-512-256/intel_gpu.md)
+- SHA3-256
+  - [Nvidia GPU(s)](results/sha3-256/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-256/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-256/intel_gpu.md)
 
 obtained after executing them on multiple accelerators.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SYCL accelerated Binary Merklization using SHA1, SHA2 & SHA3
 
 ## Motivation
 
-After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 & SHA3 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 & SHA3 families of cryptographic hash functions are data parallel, requiring to process each message block ( can be 512 -bit/ 1024 -bit ) sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2/ SHA3 families of cryptographic ( 2-to-1 ) hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
+After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 & SHA3 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 & SHA3 families of cryptographic hash functions are data parallel, requiring to process each message block ( can be 512 -bit/ 1024 -bit or padded to 1600 -bit in case of SHA3 family ) sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2/ SHA3 families of cryptographic ( 2-to-1 ) hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
 
 ```bash
   ((a, b), (c, d))          < --- [Level 1] [Root]
@@ -25,7 +25,7 @@ input   = [a, b, c, d]
 output  = [0, ((a, b), (c, d)), (a, b), (c, d)]
 ```
 
-Here in this repository, I'm keeping binary merklization kernels, implemented in SYCL, while using SHA1/ SHA2 variants as 2-to-1 hash function, which one to use is compile-time choice using pre-processor directive.
+Here in this repository, I'm keeping binary merklization kernels, implemented in SYCL, while using SHA1/ SHA2/ SHA3 variants as 2-to-1 hash function, which one to use is compile-time choice using pre-processor directive.
 
 If you happen to be interested in Binary Merklization using Rescue Prime Hash/ BLAKE3, consider seeing following links.
 
@@ -84,12 +84,16 @@ If you happen to be interested in 2-to-1 hash implementation of
 - [SHA2-512](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/example/sha2_512.cpp)
 - [SHA2-512/224](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/example/sha2_512_224.cpp)
 - [SHA2-512/256](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/example/sha2_512_256.cpp)
+- [SHA3-224](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_224.cpp)
+- [SHA3-256](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_256.cpp)
+- [SHA3-384](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_384.cpp)
+- [SHA3-512](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_512.cpp)
 
 where two digests of respective hash functions are input, in byte concatenated form, to `hash( ... )` function, consider taking a look at above hyperlinked examples.
 
 > Compile above examples using `dpcpp -fsycl example/<file>.cpp -I./include`
 
-You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/include/merklize.hpp)
+You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/4aadd99/include/merklize.hpp)
 
 ## Tests
 
@@ -137,5 +141,17 @@ I'm keeping binary merklization benchmark results of
   - [Nvidia GPU(s)](results/sha3-256/nvidia_gpu.md)
   - [Intel CPU(s)](results/sha3-256/intel_cpu.md)
   - [Intel GPU(s)](results/sha3-256/intel_gpu.md)
+- SHA3-224
+  - [Nvidia GPU(s)](results/sha3-224/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-224/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-224/intel_gpu.md)
+- SHA3-384
+  - [Nvidia GPU(s)](results/sha3-384/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-384/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-384/intel_gpu.md)
+- SHA3-512
+  - [Nvidia GPU(s)](results/sha3-512/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-512/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-512/intel_gpu.md)
 
 obtained after executing them on multiple accelerators.

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -70,6 +70,9 @@ main(int argc, char** argv)
 #elif defined SHA3_384
   std::cout << "\nBenchmarking Binary Merklization using SHA3-384" << std::endl
             << std::endl;
+#elif defined SHA3_512
+  std::cout << "\nBenchmarking Binary Merklization using SHA3-512" << std::endl
+            << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -53,6 +53,17 @@ main(int argc, char** argv)
 #elif defined SHA2_512
   std::cout << "\nBenchmarking Binary Merklization using SHA2-512" << std::endl
             << std::endl;
+#elif defined SHA2_512_224
+  std::cout << "\nBenchmarking Binary Merklization using SHA2-512/224"
+            << std::endl
+            << std::endl;
+#elif defined SHA2_512_256
+  std::cout << "\nBenchmarking Binary Merklization using SHA2-512/256"
+            << std::endl
+            << std::endl;
+#elif defined SHA3_256
+  std::cout << "\nBenchmarking Binary Merklization using SHA3-256" << std::endl
+            << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -67,6 +67,9 @@ main(int argc, char** argv)
 #elif defined SHA3_224
   std::cout << "\nBenchmarking Binary Merklization using SHA3-224" << std::endl
             << std::endl;
+#elif defined SHA3_384
+  std::cout << "\nBenchmarking Binary Merklization using SHA3-384" << std::endl
+            << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -64,6 +64,9 @@ main(int argc, char** argv)
 #elif defined SHA3_256
   std::cout << "\nBenchmarking Binary Merklization using SHA3-256" << std::endl
             << std::endl;
+#elif defined SHA3_224
+  std::cout << "\nBenchmarking Binary Merklization using SHA3-224" << std::endl
+            << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/example/sha3_256.cpp
+++ b/example/sha3_256.cpp
@@ -1,0 +1,68 @@
+#include "sha3_256.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA3-256 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 32
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[32] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 32
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[32] = { 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15 };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_256(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[32] = {
+    121, 136, 237, 222, 17, 197, 60,  82,  161, 87, 52,  66,  251, 235, 8,  125,
+    1,   95,  88,  134, 1,  235, 132, 182, 114, 55, 207, 202, 17,  104, 74, 95
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  // compute 2-to-1 hash
+  q.single_task<class kernelExampleSHA3_256>(
+    [=]() { sha3_256::hash(in, out); });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/example/sha3_384.cpp
+++ b/example/sha3_384.cpp
@@ -1,0 +1,72 @@
+#include "sha3_384.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA3-384 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 48
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[48] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 48
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[48] = { 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15 };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_384(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[48] = {
+    25,  254, 93,  230, 2,  191, 78,  51,  238, 228, 239, 160,
+    231, 101, 38,  216, 38, 8,   135, 59,  34,  169, 154, 20,
+    221, 245, 50,  59,  27, 9,   21,  234, 249, 223, 45,  73,
+    214, 0,   146, 51,  25, 83,  0,   0,   111, 210, 47,  206
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  // compute 2-to-1 hash
+  q.single_task<class kernelExampleSHA3_384>(
+    [=]() { sha3_384::hash(in, out); });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/example/sha3_512.cpp
+++ b/example/sha3_512.cpp
@@ -1,0 +1,75 @@
+#include "sha3_512.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA3-512 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 64
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[64] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 64
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[64] = {
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15
+  };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_512(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[64] = {
+    73,  228, 11,  92,  59,  196, 139, 212, 163, 66,  229, 66,  106,
+    155, 168, 55,  241, 215, 241, 253, 75,  61,  91,  215, 172, 186,
+    250, 212, 10,  12,  61,  253, 80,  236, 57,  238, 27,  53,  53,
+    20,  81,  55,  63,  196, 104, 93,  94,  74,  19,  36,  181, 15,
+    41,  21,  198, 35,  60,  3,   65,  232, 15,  78,  220, 61
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  // compute 2-to-1 hash
+  q.single_task<class kernelExampleSHA3_512>(
+    [=]() { sha3_512::hash(in, out); });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -45,6 +45,9 @@ benchmark_merklize(sycl::queue& q,
 #elif defined SHA3_256
   const size_t i_size = leaf_cnt * sha3_256::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * sha3_256::OUT_LEN_BYTES; // in bytes
+#elif defined SHA3_224
+  const size_t i_size = leaf_cnt * sha3_224::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha3_224::OUT_LEN_BYTES; // in bytes
 #endif
 
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256
@@ -60,7 +63,7 @@ benchmark_merklize(sycl::queue& q,
   sycl::ulong* o_h = static_cast<sycl::ulong*>(sycl::malloc_host(o_size, q));
   sycl::ulong* i_d = static_cast<sycl::ulong*>(sycl::malloc_device(i_size, q));
   sycl::ulong* o_d = static_cast<sycl::ulong*>(sycl::malloc_device(o_size, q));
-#elif defined SHA3_256
+#elif defined SHA3_256 || defined SHA3_224
   // allocate resources
   sycl::uchar* i_h = static_cast<sycl::uchar*>(sycl::malloc_host(i_size, q));
   sycl::uchar* o_h = static_cast<sycl::uchar*>(sycl::malloc_host(o_size, q));
@@ -119,6 +122,8 @@ benchmark_merklize(sycl::queue& q,
                      (sha2_512_256::OUT_LEN_BYTES >> 3)
 #elif defined SHA3_256
                      (sha3_256::OUT_LEN_BYTES)
+#elif defined SHA3_224
+                     (sha3_224::OUT_LEN_BYTES)
 #endif
 
          ;

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -51,6 +51,9 @@ benchmark_merklize(sycl::queue& q,
 #elif defined SHA3_384
   const size_t i_size = leaf_cnt * sha3_384::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * sha3_384::OUT_LEN_BYTES; // in bytes
+#elif defined SHA3_512
+  const size_t i_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
 #endif
 
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256
@@ -66,7 +69,8 @@ benchmark_merklize(sycl::queue& q,
   sycl::ulong* o_h = static_cast<sycl::ulong*>(sycl::malloc_host(o_size, q));
   sycl::ulong* i_d = static_cast<sycl::ulong*>(sycl::malloc_device(i_size, q));
   sycl::ulong* o_d = static_cast<sycl::ulong*>(sycl::malloc_device(o_size, q));
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
   // allocate resources
   sycl::uchar* i_h = static_cast<sycl::uchar*>(sycl::malloc_host(i_size, q));
   sycl::uchar* o_h = static_cast<sycl::uchar*>(sycl::malloc_host(o_size, q));
@@ -129,6 +133,8 @@ benchmark_merklize(sycl::queue& q,
                      (sha3_224::OUT_LEN_BYTES)
 #elif defined SHA3_384
                      (sha3_384::OUT_LEN_BYTES)
+#elif defined SHA3_512
+                     (sha3_512::OUT_LEN_BYTES)
 #endif
 
          ;

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -42,6 +42,9 @@ benchmark_merklize(sycl::queue& q,
 #elif defined SHA2_512_256
   const size_t i_size = leaf_cnt * sha2_512_256::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * sha2_512_256::OUT_LEN_BYTES; // in bytes
+#elif defined SHA3_256
+  const size_t i_size = leaf_cnt * sha3_256::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha3_256::OUT_LEN_BYTES; // in bytes
 #endif
 
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256
@@ -57,6 +60,12 @@ benchmark_merklize(sycl::queue& q,
   sycl::ulong* o_h = static_cast<sycl::ulong*>(sycl::malloc_host(o_size, q));
   sycl::ulong* i_d = static_cast<sycl::ulong*>(sycl::malloc_device(i_size, q));
   sycl::ulong* o_d = static_cast<sycl::ulong*>(sycl::malloc_device(o_size, q));
+#elif defined SHA3_256
+  // allocate resources
+  sycl::uchar* i_h = static_cast<sycl::uchar*>(sycl::malloc_host(i_size, q));
+  sycl::uchar* o_h = static_cast<sycl::uchar*>(sycl::malloc_host(o_size, q));
+  sycl::uchar* i_d = static_cast<sycl::uchar*>(sycl::malloc_device(i_size, q));
+  sycl::uchar* o_d = static_cast<sycl::uchar*>(sycl::malloc_device(o_size, q));
 #endif
 
   // Set all intermediate nodes to zero bytes,
@@ -108,6 +117,8 @@ benchmark_merklize(sycl::queue& q,
                      (32 >> 3)
 #elif defined SHA2_512_256
                      (sha2_512_256::OUT_LEN_BYTES >> 3)
+#elif defined SHA3_256
+                     (sha3_256::OUT_LEN_BYTES)
 #endif
 
          ;

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -48,6 +48,9 @@ benchmark_merklize(sycl::queue& q,
 #elif defined SHA3_224
   const size_t i_size = leaf_cnt * sha3_224::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * sha3_224::OUT_LEN_BYTES; // in bytes
+#elif defined SHA3_384
+  const size_t i_size = leaf_cnt * sha3_384::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha3_384::OUT_LEN_BYTES; // in bytes
 #endif
 
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256
@@ -63,7 +66,7 @@ benchmark_merklize(sycl::queue& q,
   sycl::ulong* o_h = static_cast<sycl::ulong*>(sycl::malloc_host(o_size, q));
   sycl::ulong* i_d = static_cast<sycl::ulong*>(sycl::malloc_device(i_size, q));
   sycl::ulong* o_d = static_cast<sycl::ulong*>(sycl::malloc_device(o_size, q));
-#elif defined SHA3_256 || defined SHA3_224
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
   // allocate resources
   sycl::uchar* i_h = static_cast<sycl::uchar*>(sycl::malloc_host(i_size, q));
   sycl::uchar* o_h = static_cast<sycl::uchar*>(sycl::malloc_host(o_size, q));
@@ -124,6 +127,8 @@ benchmark_merklize(sycl::queue& q,
                      (sha3_256::OUT_LEN_BYTES)
 #elif defined SHA3_224
                      (sha3_224::OUT_LEN_BYTES)
+#elif defined SHA3_384
+                     (sha3_384::OUT_LEN_BYTES)
 #endif
 
          ;

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -3,7 +3,7 @@
 #if !(defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                  \
       defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
       defined SHA2_512_256 || defined SHA3_256 || defined SHA3_224 ||          \
-      defined SHA3_384)
+      defined SHA3_384 || defined SHA3_512)
 #define SHA2_256
 #endif
 
@@ -37,6 +37,9 @@
 #elif defined SHA3_384
 #include "sha3_384.hpp"
 #pragma message "Choosing to compile Merklization with SHA3-384 !"
+#elif defined SHA3_512
+#include "sha3_512.hpp"
+#pragma message "Choosing to compile Merklization with SHA3-512 !"
 #endif
 
 // Binary merklization --- collects motivation from
@@ -52,7 +55,8 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          const sycl::ulong* __restrict leaf_nodes,
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
          const sycl::uchar* __restrict leaf_nodes,
 #endif
 
@@ -64,7 +68,8 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          sycl::ulong* const __restrict intermediates,
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
          sycl::uchar* const __restrict intermediates,
 #endif
 
@@ -108,12 +113,15 @@ merklize(sycl::queue& q,
 #elif defined SHA3_384
   assert(i_size == leaf_cnt * sha3_384::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha3_384::OUT_LEN_BYTES);
+#elif defined SHA3_512
+  assert(i_size == leaf_cnt * sha3_512::OUT_LEN_BYTES);
+  assert(o_size == (itmd_cnt + 1) * sha3_512::OUT_LEN_BYTES);
 #endif
 
   // both input and output allocation has same size
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                    \
   defined SHA2_384 || defined SHA2_512 || defined SHA2_512_256 ||              \
-  defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+  defined SHA3_256 || defined SHA3_224 || defined SHA3_384 || defined SHA3_512
 
   assert(i_size == o_size);
 
@@ -151,7 +159,8 @@ merklize(sycl::queue& q,
   //
   // note that `o_size` is in terms of bytes
   const size_t elm_cnt = o_size >> 3;
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
   // # -of 8 -bit unsigned integers ( read a byte ), which can be contiguously
   // placed on output memory allocation
   //
@@ -215,6 +224,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_384
         const size_t in_idx = idx * sha3_384::IN_LEN_BYTES;
         const size_t out_idx = idx * sha3_384::OUT_LEN_BYTES;
+#elif defined SHA3_512
+        const size_t in_idx = idx * sha3_512::IN_LEN_BYTES;
+        const size_t out_idx = idx * sha3_512::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -253,6 +265,11 @@ merklize(sycl::queue& q,
         sycl::uchar* out = intermediates + o_offset + out_idx;
 
         sha3_384::hash(in, out);
+#elif defined SHA3_512
+        const sycl::uchar* in = leaf_nodes + i_offset + in_idx;
+        sycl::uchar* out = intermediates + o_offset + out_idx;
+
+        sha3_512::hash(in, out);
 #endif
       });
   });
@@ -378,6 +395,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_384
           const size_t in_idx = idx * sha3_384::IN_LEN_BYTES;
           const size_t out_idx = idx * sha3_384::OUT_LEN_BYTES;
+#elif defined SHA3_512
+          const size_t in_idx = idx * sha3_512::IN_LEN_BYTES;
+          const size_t out_idx = idx * sha3_512::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -421,6 +441,11 @@ merklize(sycl::queue& q,
           sycl::uchar* out = intermediates + o_offset_ + out_idx;
 
           sha3_384::hash(in, out);
+#elif defined SHA3_512
+          const sycl::uchar* in = intermediates + i_offset_ + in_idx;
+          sycl::uchar* out = intermediates + o_offset_ + out_idx;
+
+          sha3_512::hash(in, out);
 #endif
         });
     });

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -2,7 +2,8 @@
 
 #if !(defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                  \
       defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
-      defined SHA2_512_256 || defined SHA3_256 || defined SHA3_224)
+      defined SHA2_512_256 || defined SHA3_256 || defined SHA3_224 ||          \
+      defined SHA3_384)
 #define SHA2_256
 #endif
 
@@ -33,6 +34,9 @@
 #elif defined SHA3_224
 #include "sha3_224.hpp"
 #pragma message "Choosing to compile Merklization with SHA3-224 !"
+#elif defined SHA3_384
+#include "sha3_384.hpp"
+#pragma message "Choosing to compile Merklization with SHA3-384 !"
 #endif
 
 // Binary merklization --- collects motivation from
@@ -48,7 +52,7 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          const sycl::ulong* __restrict leaf_nodes,
-#elif defined SHA3_256 || defined SHA3_224
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
          const sycl::uchar* __restrict leaf_nodes,
 #endif
 
@@ -60,7 +64,7 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          sycl::ulong* const __restrict intermediates,
-#elif defined SHA3_256 || defined SHA3_224
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
          sycl::uchar* const __restrict intermediates,
 #endif
 
@@ -101,12 +105,15 @@ merklize(sycl::queue& q,
 #elif defined SHA3_224
   assert(i_size == leaf_cnt * sha3_224::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha3_224::OUT_LEN_BYTES);
+#elif defined SHA3_384
+  assert(i_size == leaf_cnt * sha3_384::OUT_LEN_BYTES);
+  assert(o_size == (itmd_cnt + 1) * sha3_384::OUT_LEN_BYTES);
 #endif
 
   // both input and output allocation has same size
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                    \
   defined SHA2_384 || defined SHA2_512 || defined SHA2_512_256 ||              \
-  defined SHA3_256 || defined SHA3_224
+  defined SHA3_256 || defined SHA3_224 || defined SHA3_384
 
   assert(i_size == o_size);
 
@@ -144,7 +151,7 @@ merklize(sycl::queue& q,
   //
   // note that `o_size` is in terms of bytes
   const size_t elm_cnt = o_size >> 3;
-#elif defined SHA3_256 || defined SHA3_224
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
   // # -of 8 -bit unsigned integers ( read a byte ), which can be contiguously
   // placed on output memory allocation
   //
@@ -205,6 +212,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_224
         const size_t in_idx = idx * sha3_224::IN_LEN_BYTES;
         const size_t out_idx = idx * sha3_224::OUT_LEN_BYTES;
+#elif defined SHA3_384
+        const size_t in_idx = idx * sha3_384::IN_LEN_BYTES;
+        const size_t out_idx = idx * sha3_384::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -238,6 +248,11 @@ merklize(sycl::queue& q,
         sycl::uchar* out = intermediates + o_offset + out_idx;
 
         sha3_224::hash(in, out);
+#elif defined SHA3_384
+        const sycl::uchar* in = leaf_nodes + i_offset + in_idx;
+        sycl::uchar* out = intermediates + o_offset + out_idx;
+
+        sha3_384::hash(in, out);
 #endif
       });
   });
@@ -360,6 +375,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_224
           const size_t in_idx = idx * sha3_224::IN_LEN_BYTES;
           const size_t out_idx = idx * sha3_224::OUT_LEN_BYTES;
+#elif defined SHA3_384
+          const size_t in_idx = idx * sha3_384::IN_LEN_BYTES;
+          const size_t out_idx = idx * sha3_384::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -398,6 +416,11 @@ merklize(sycl::queue& q,
           sycl::uchar* out = intermediates + o_offset_ + out_idx;
 
           sha3_224::hash(in, out);
+#elif defined SHA3_384
+          const sycl::uchar* in = intermediates + i_offset_ + in_idx;
+          sycl::uchar* out = intermediates + o_offset_ + out_idx;
+
+          sha3_384::hash(in, out);
 #endif
         });
     });

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -2,7 +2,7 @@
 
 #if !(defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                  \
       defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
-      defined SHA2_512_256 || defined SHA3_256)
+      defined SHA2_512_256 || defined SHA3_256 || defined SHA3_224)
 #define SHA2_256
 #endif
 
@@ -30,6 +30,9 @@
 #elif defined SHA3_256
 #include "sha3_256.hpp"
 #pragma message "Choosing to compile Merklization with SHA3-256 !"
+#elif defined SHA3_224
+#include "sha3_224.hpp"
+#pragma message "Choosing to compile Merklization with SHA3-224 !"
 #endif
 
 // Binary merklization --- collects motivation from
@@ -45,7 +48,7 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          const sycl::ulong* __restrict leaf_nodes,
-#elif defined SHA3_256
+#elif defined SHA3_256 || defined SHA3_224
          const sycl::uchar* __restrict leaf_nodes,
 #endif
 
@@ -57,7 +60,7 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          sycl::ulong* const __restrict intermediates,
-#elif defined SHA3_256
+#elif defined SHA3_256 || defined SHA3_224
          sycl::uchar* const __restrict intermediates,
 #endif
 
@@ -95,12 +98,15 @@ merklize(sycl::queue& q,
 #elif defined SHA3_256
   assert(i_size == leaf_cnt * sha3_256::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha3_256::OUT_LEN_BYTES);
+#elif defined SHA3_224
+  assert(i_size == leaf_cnt * sha3_224::OUT_LEN_BYTES);
+  assert(o_size == (itmd_cnt + 1) * sha3_224::OUT_LEN_BYTES);
 #endif
 
   // both input and output allocation has same size
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                    \
   defined SHA2_384 || defined SHA2_512 || defined SHA2_512_256 ||              \
-  defined SHA3_256
+  defined SHA3_256 || defined SHA3_224
 
   assert(i_size == o_size);
 
@@ -138,7 +144,7 @@ merklize(sycl::queue& q,
   //
   // note that `o_size` is in terms of bytes
   const size_t elm_cnt = o_size >> 3;
-#elif defined SHA3_256
+#elif defined SHA3_256 || defined SHA3_224
   // # -of 8 -bit unsigned integers ( read a byte ), which can be contiguously
   // placed on output memory allocation
   //
@@ -196,6 +202,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_256
         const size_t in_idx = idx * sha3_256::IN_LEN_BYTES;
         const size_t out_idx = idx * sha3_256::OUT_LEN_BYTES;
+#elif defined SHA3_224
+        const size_t in_idx = idx * sha3_224::IN_LEN_BYTES;
+        const size_t out_idx = idx * sha3_224::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -224,6 +233,11 @@ merklize(sycl::queue& q,
         sycl::uchar* out = intermediates + o_offset + out_idx;
 
         sha3_256::hash(in, out);
+#elif defined SHA3_224
+        const sycl::uchar* in = leaf_nodes + i_offset + in_idx;
+        sycl::uchar* out = intermediates + o_offset + out_idx;
+
+        sha3_224::hash(in, out);
 #endif
       });
   });
@@ -343,6 +357,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_256
           const size_t in_idx = idx * sha3_256::IN_LEN_BYTES;
           const size_t out_idx = idx * sha3_256::OUT_LEN_BYTES;
+#elif defined SHA3_224
+          const size_t in_idx = idx * sha3_224::IN_LEN_BYTES;
+          const size_t out_idx = idx * sha3_224::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -376,6 +393,11 @@ merklize(sycl::queue& q,
           sycl::uchar* out = intermediates + o_offset_ + out_idx;
 
           sha3_256::hash(in, out);
+#elif defined SHA3_224
+          const sycl::uchar* in = intermediates + i_offset_ + in_idx;
+          sycl::uchar* out = intermediates + o_offset_ + out_idx;
+
+          sha3_224::hash(in, out);
 #endif
         });
     });

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <CL/sycl.hpp>
+#include <bitset>
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is modified state array
+//
+// See specification of `θ` step mapping function in section 3.2.1
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline void
+θ(std::bitset<64>** const state)
+{
+  std::bitset<64> c[5];
+
+  // see step 1 of algorithm 1 in http://dx.doi.org/10.6028/NIST.FIPS.202
+#pragma unroll 5
+  for (size_t x = 0; x < 5; x++) {
+    c[x] = state[x][0] ^ state[x][1] ^ state[x][2] ^ state[x][3] ^ state[x][4];
+  }
+
+  std::bitset<64> d[5];
+
+  // see step 2 of algorithm 1 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  for (size_t x = 0; x < 5; x++) {
+#pragma unroll 64
+    for (size_t z = 0; z < 64; z++) {
+      d[x][63 - z] = c[(x - 1) % 5][63 - z] ^ c[(x + 1) % 5][63 - (z - 1) % 64];
+    }
+  }
+
+  // see step 3 of algorithm 1 in http://dx.doi.org/10.6028/NIST.FIPS.202
+#pragma unroll 5
+  for (size_t y = 0; y < 5; y++) {
+#pragma unroll 5
+    for (size_t x = 0; x < 5; x++) {
+      state[x][y] ^= d[x];
+    }
+  }
+}

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -28,9 +28,9 @@ static inline void
   for (size_t x = 0; x < 5; x++) {
     const sycl::ulong tmp0 = state[x] ^ state[x + 5];
     const sycl::ulong tmp1 = state[x + 10] ^ state[x + 15];
-    const sycl::ulong tmp3 = tmp0 ^ tmp1 ^ state[x + 20];
+    const sycl::ulong tmp2 = tmp0 ^ tmp1 ^ state[x + 20];
 
-    c[x] = tmp3;
+    c[x] = tmp2;
   }
 
 // see step 2 of algorithm 1

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -93,3 +93,26 @@ inline void
     // a single slice
   }
 }
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is modified state array
+//
+// See specification of `χ` step mapping function in section 3.2.4
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline void
+χ(const std::bitset<64>** state_in, std::bitset<64>** const state_out)
+{
+  // step 1 of algorithm 4 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  for (size_t x = 0; x < 5; x++) {
+    for (size_t y = 0; y < 5; y++) {
+      for (size_t z = 0; z < 64; z++) {
+        bool v0 = state_in[(x + 1) % 5][y][63 - z] ^ 1;
+        bool v1 = state_in[(x + 2) % 5][y][63 - z];
+        bool v2 = v0 & v1;
+
+        state_out[x][y][63 - z] = state_in[x][y][63 - z] ^ v2;
+      }
+    }
+  }
+}

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -13,7 +13,7 @@ inline void
 {
   std::bitset<64> c[5];
 
-  // see step 1 of algorithm 1 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // see step 1 of algorithm 1
 #pragma unroll 5
   for (size_t x = 0; x < 5; x++) {
     c[x] = state[x][0] ^ state[x][1] ^ state[x][2] ^ state[x][3] ^ state[x][4];
@@ -21,7 +21,7 @@ inline void
 
   std::bitset<64> d[5];
 
-  // see step 2 of algorithm 1 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // see step 2 of algorithm 1
   for (size_t x = 0; x < 5; x++) {
 #pragma unroll 64
     for (size_t z = 0; z < 64; z++) {
@@ -29,7 +29,7 @@ inline void
     }
   }
 
-  // see step 3 of algorithm 1 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // see step 3 of algorithm 1
 #pragma unroll 5
   for (size_t y = 0; y < 5; y++) {
 #pragma unroll 5
@@ -48,23 +48,23 @@ inline void
 inline void
 ρ(const std::bitset<64>** state_in, std::bitset<64>** const state_out)
 {
-  // step 1 of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // step 1 of algorithm 2
   state_out[0][0] = state_in[0][0];
 
-  // step 2 of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // step 2 of algorithm 2
   size_t x = 1;
   size_t y = 0;
 
-  // step 3 of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // step 3 of algorithm 2
   for (size_t t = 0; t < 24; t++) {
-    // step 3a of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+    // step 3a of algorithm 2
     for (size_t z = 0; z < 64; z++) {
       size_t _z = 63 - (z - (((t + 1) * (t + 2)) / 2)) % 64;
 
       state_out[x][y][z] = state_in[x][y][_z];
     }
 
-    // step 3b of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+    // step 3b of algorithm 2
     const size_t tmp = x;
     x = y;
     y = (2 * tmp + 3 * y) % 5;
@@ -80,7 +80,7 @@ inline void
 inline void
 π(const std::bitset<64>** state_in, std::bitset<64>** const state_out)
 {
-  // step 1 of algorithm 3 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // step 1 of algorithm 3
   for (size_t z = 0; z < 64; z++) {
     // a single slice
 #pragma unroll 5
@@ -103,7 +103,7 @@ inline void
 inline void
 χ(const std::bitset<64>** state_in, std::bitset<64>** const state_out)
 {
-  // step 1 of algorithm 4 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  // step 1 of algorithm 4
   for (size_t x = 0; x < 5; x++) {
     for (size_t y = 0; y < 5; y++) {
       for (size_t z = 0; z < 64; z++) {
@@ -115,4 +115,48 @@ inline void
       }
     }
   }
+}
+
+// See algorithm 5 in section 3.2.5 of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline bool
+rc(size_t t)
+{
+  if (t % 255 == 0) {
+    return 1;
+  }
+
+  std::bitset<9> r{ 0b010000000 };
+  for (size_t i = 1; i <= t % 255; i++) {
+    r[8] = r[8] ^ r[0];
+    r[4] = r[4] ^ r[0];
+    r[3] = r[3] ^ r[0];
+    r[2] = r[2] ^ r[0];
+
+    r[0] = 0;
+  }
+
+  return r[7];
+}
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array, along with round index ∈ [0, 24)
+// Output is modified state array
+//
+// See specification of `ι` step mapping function in section 3.2.5
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline void
+ι(std::bitset<64>** const state, size_t round_index)
+{
+  // step 2 of algorithm 6
+  std::bitset<64> RC;
+  RC.reset();
+
+  // step 3 of algorithm 6
+  for (size_t j = 0; j < 7; j++) {
+    RC[63 - ((1 << j) - 1)] = rc(j + 7 * round_index);
+  }
+
+  // step 4 of algorithm 6
+  state[0][0] ^= RC;
 }

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -235,3 +235,42 @@ keccak_p(std::bitset<1600>& s)
   // step 3 of algorithm 7
   to_bit_string(state, s);
 }
+
+// Modern C++ feature to compile-time ensure that template argument position,
+// passed to following `bit_at` routine ∈ [0, 8)
+template<typename T>
+constexpr bool
+is_less_than(T pos)
+{
+  return pos >= 0 && pos < 8;
+}
+
+// Extracts bit from one of 8 possible bit positions of a byte
+//
+// Note indexing of bits in specified bytes is performed left to
+// right ascending order
+//
+// Meaning if byte = 0b11110000,
+// then assert(byte[0] == 1 && byte[7] = 0)
+template<uint8_t pos>
+inline bool
+bit_at(sycl::uchar byte) requires(is_less_than(pos))
+{
+  return (byte >> (7 - pos)) & 0b1;
+}
+
+// Return value many zero bits to be padded to original message bit string
+//
+// Note, this function itself doesn't perform any padding, instead  it's just
+// used for deciding how many zero bits to be padded before keccak_p[b, n_r]
+// permutation can be applied
+//
+// In times, it can be the case that no zero bits to be padded i.e. returns 0
+// from this function when those cases are encountered !
+//
+// See algorithm 9 in section 5.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline size_t
+pad(size_t rate, size_t in_len)
+{
+  return -(in_len + 2) % rate;
+}

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -38,3 +38,35 @@ inline void
     }
   }
 }
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is modified state array
+//
+// See specification of `ρ` step mapping function in section 3.2.2
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline void
+ρ(const std::bitset<64>** state_in, std::bitset<64>** const state_out)
+{
+  // step 1 of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  state_out[0][0] = state_in[0][0];
+
+  // step 2 of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  size_t x = 1;
+  size_t y = 0;
+
+  // step 3 of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  for (size_t t = 0; t < 24; t++) {
+    // step 3a of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+    for (size_t z = 0; z < 64; z++) {
+      size_t _z = 63 - (z - (((t + 1) * (t + 2)) / 2)) % 64;
+
+      state_out[x][y][z] = state_in[x][y][_z];
+    }
+
+    // step 3b of algorithm 2 in http://dx.doi.org/10.6028/NIST.FIPS.202
+    const size_t tmp = x;
+    x = y;
+    y = (2 * tmp + 3 * y) % 5;
+  }
+}

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -237,10 +237,10 @@ keccak_p(std::bitset<1600>& s)
 }
 
 // Modern C++ feature to compile-time ensure that template argument position,
-// passed to following `bit_at` routine ∈ [0, 8)
+// passed to following `{get,set}_bit_at` routine ∈ [0, 8)
 template<typename T>
 constexpr bool
-is_less_than(T pos)
+is_valid_bit_pos(T pos)
 {
   return pos >= 0 && pos < 8;
 }
@@ -254,9 +254,23 @@ is_less_than(T pos)
 // then assert(byte[0] == 1 && byte[7] = 0)
 template<uint8_t pos>
 inline bool
-bit_at(sycl::uchar byte) requires(is_less_than(pos))
+get_bit_at(sycl::uchar byte) requires(is_valid_bit_pos(pos))
 {
   return (byte >> (7 - pos)) & 0b1;
+}
+
+// Sets bit value at one of 8 possible bit positions in a byte
+//
+// Note indexing of bits in specified bytes is performed left to
+// right ascending order
+//
+// Meaning if byte = 0b11110000,
+// then assert(byte[0] == 1 && byte[7] = 0)
+template<uint8_t pos>
+inline sycl::uchar
+set_bit_at(bool bit) requires(is_valid_bit_pos(pos))
+{
+  return static_cast<sycl::uchar>(bit) << (7 - pos);
 }
 
 // Return value many zero bits to be padded to original message bit string

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -70,3 +70,26 @@ inline void
     y = (2 * tmp + 3 * y) % 5;
   }
 }
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is modified state array
+//
+// See specification of `π` step mapping function in section 3.2.3
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+inline void
+π(const std::bitset<64>** state_in, std::bitset<64>** const state_out)
+{
+  // step 1 of algorithm 3 in http://dx.doi.org/10.6028/NIST.FIPS.202
+  for (size_t z = 0; z < 64; z++) {
+    // a single slice
+#pragma unroll 5
+    for (size_t x = 0; x < 5; x++) {
+#pragma unroll 5
+      for (size_t y = 0; y < 5; y++) {
+        state_out[x][y][63 - z] = state_in[(x + 3 * y) % 5][x][63 - z];
+      }
+    }
+    // a single slice
+  }
+}

--- a/include/sha3_224.hpp
+++ b/include/sha3_224.hpp
@@ -1,0 +1,119 @@
+#pragma once
+#include "sha3.hpp"
+
+namespace sha3_224 {
+
+// SHA3-224 specific input/ output width constants, taken from
+// table 4's in section A.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+constexpr size_t IN_LEN_BITS = 448;
+constexpr size_t IN_LEN_BYTES = IN_LEN_BITS >> 3;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+// From input byte array ( = 56 bytes ) preparing 5 x 5 x 64 keccak state array
+// as twenty five 64 -bit unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+void
+to_state_array(const sycl::uchar* __restrict in,
+               sycl::ulong* const __restrict state)
+{ 
+#pragma unroll 7
+  for (size_t i = 0; i < (IN_LEN_BYTES >> 3); i++) {
+    state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+               static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+               static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+               static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+               static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+               static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+               static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+               static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+  }
+
+  // see how 0b01 is appended to input message bits in section
+  // 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+  //
+  // ! read right to left !
+  //
+  // also notice left most 1 added due to padding requirement
+  // as specified in section 5.1 of above linked specification
+  state[7] = 0b110ull;
+
+#pragma unroll 9
+  for (size_t i = 8; i < 17; i++) {
+    state[i] = 0ull;
+  }
+
+  // this 1 is added to input message bits due to padding requirement
+  // ( pad10*1 ) written in section 5.1 of
+  // http://dx.doi.org/10.6028/NIST.FIPS.202
+  //
+  // ! read right to left, so it's actually 1 << 63 !
+  state[17] = 9223372036854775808ull;
+
+#pragma unroll 7
+  for (size_t i = 18; i < 25; i++) {
+    state[i] = 0ull;
+  }
+}
+
+// From absorbed hash state array of dimension 5 x 5 x 64, produces 28 -bytes
+// digest using method defined in section 3.1.3 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
+// B.1 of above hyperlinked document
+void
+to_digest_bytes(const sycl::ulong* __restrict in,
+                sycl::uchar* const __restrict digest)
+{
+  // writing first 24 -bytes of digest from first three lanes
+  // of state array i.e. lane(0, 0), lane(1, 0),lane(2, 0)
+#pragma unroll 3
+  for (size_t i = 0; i < 3; i++) {
+    const sycl::ulong lane = in[i];
+
+    digest[(i << 3) + 0] = static_cast<sycl::uchar>((lane >> 0) & 0xffull);
+    digest[(i << 3) + 1] = static_cast<sycl::uchar>((lane >> 8) & 0xffull);
+    digest[(i << 3) + 2] = static_cast<sycl::uchar>((lane >> 16) & 0xffull);
+    digest[(i << 3) + 3] = static_cast<sycl::uchar>((lane >> 24) & 0xffull);
+    digest[(i << 3) + 4] = static_cast<sycl::uchar>((lane >> 32) & 0xffull);
+    digest[(i << 3) + 5] = static_cast<sycl::uchar>((lane >> 40) & 0xffull);
+    digest[(i << 3) + 6] = static_cast<sycl::uchar>((lane >> 48) & 0xffull);
+    digest[(i << 3) + 7] = static_cast<sycl::uchar>((lane >> 56) & 0xffull);
+  }
+
+  // and then computing final 4 bytes of digest from fourth lane of
+  // state array i.e. lane(3, 0)
+  //
+  // for understanding meaning of lane notation, you want to see
+  // section 3.1.1 and section 2.2 of http://dx.doi.org/10.6028/NIST.FIPS.202
+  const sycl::ulong lane = in[3];
+  digest[(3 << 3) + 0] = static_cast<sycl::uchar>((lane >> 0) & 0xffull);
+  digest[(3 << 3) + 1] = static_cast<sycl::uchar>((lane >> 8) & 0xffull);
+  digest[(3 << 3) + 2] = static_cast<sycl::uchar>((lane >> 16) & 0xffull);
+  digest[(3 << 3) + 3] = static_cast<sycl::uchar>((lane >> 24) & 0xffull);
+}
+
+// SHA3-224 2-to-1 hasher, where input is 56 contiguous bytes which is hashed
+// to produce 28 -bytes output
+//
+// This function itself doesn't do much instead of calling other functions
+// which actually
+// - prepares state bit array from input byte array
+// - permutes input using `keccak-p[b, n_r]`
+// - truncates first 224 -bits from state bit array
+//
+// See section 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+void
+hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
+{
+  sycl::ulong state[25];
+
+  to_state_array(in, state);
+  keccak_p(state);
+  to_digest_bytes(state, digest);
+}
+
+}

--- a/include/sha3_224.hpp
+++ b/include/sha3_224.hpp
@@ -20,7 +20,7 @@ constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
 void
 to_state_array(const sycl::uchar* __restrict in,
                sycl::ulong* const __restrict state)
-{ 
+{
 #pragma unroll 7
   for (size_t i = 0; i < (IN_LEN_BYTES >> 3); i++) {
     state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -60,6 +60,29 @@ to_state_array(const sycl::uchar* __restrict in,
   }
 }
 
+// From absorbed hash state array of dimension 5 x 5 x 64, produces 32 -bytes
+// digest using method defined in section 3.1.3 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
+// B.1 of above hyperlinked document
+void
+to_digest_bytes(const sycl::ulong* __restrict in,
+                sycl::uchar* const __restrict digest)
+{
+#pragma unroll 4
+  for (size_t i = 0; i < 4; i++) {
+    const sycl::ulong lane = in[i];
+
+    digest[(i << 3) + 0] = static_cast<sycl::uchar>((lane >> 0) & 0xffull);
+    digest[(i << 3) + 1] = static_cast<sycl::uchar>((lane >> 8) & 0xffull);
+    digest[(i << 3) + 2] = static_cast<sycl::uchar>((lane >> 16) & 0xffull);
+    digest[(i << 3) + 3] = static_cast<sycl::uchar>((lane >> 24) & 0xffull);
+    digest[(i << 3) + 4] = static_cast<sycl::uchar>((lane >> 32) & 0xffull);
+    digest[(i << 3) + 5] = static_cast<sycl::uchar>((lane >> 40) & 0xffull);
+    digest[(i << 3) + 6] = static_cast<sycl::uchar>((lane >> 48) & 0xffull);
+    digest[(i << 3) + 7] = static_cast<sycl::uchar>((lane >> 56) & 0xffull);
+  }
+}
+
 // Given two ( byte concatenated ) SHA3-256 digests ( i.e. 64 -bytes ), prepares
 // bit string of length 1600, which can be passed to keccak_p[b, n_r]
 // permutation function, in later phase

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -7,20 +7,20 @@ namespace sha3_256 {
 // bit string of length 1600, which can be passed to keccak_p[b, n_r]
 // permutation function, in later phase
 void
-prepare_bit_string(sycl::uchar* const in, std::bitset<1600>& s)
+prepare_bit_string(const sycl::uchar* in, std::bitset<1600>& s)
 {
   s.reset();
 
   size_t s_idx = 1599;
   for (size_t i = 0; i < 64; i++) {
-    s[s_idx--] = bit_at<0>(*(in + i));
-    s[s_idx--] = bit_at<1>(*(in + i));
-    s[s_idx--] = bit_at<2>(*(in + i));
-    s[s_idx--] = bit_at<3>(*(in + i));
-    s[s_idx--] = bit_at<4>(*(in + i));
-    s[s_idx--] = bit_at<5>(*(in + i));
-    s[s_idx--] = bit_at<6>(*(in + i));
-    s[s_idx--] = bit_at<7>(*(in + i));
+    s[s_idx--] = get_bit_at<0>(*(in + i));
+    s[s_idx--] = get_bit_at<1>(*(in + i));
+    s[s_idx--] = get_bit_at<2>(*(in + i));
+    s[s_idx--] = get_bit_at<3>(*(in + i));
+    s[s_idx--] = get_bit_at<4>(*(in + i));
+    s[s_idx--] = get_bit_at<5>(*(in + i));
+    s[s_idx--] = get_bit_at<6>(*(in + i));
+    s[s_idx--] = get_bit_at<7>(*(in + i));
   }
 
   s[s_idx--] = 0;
@@ -31,6 +31,21 @@ prepare_bit_string(sycl::uchar* const in, std::bitset<1600>& s)
     s[s_idx--] = 0;
   }
   s[s_idx--] = 1;
+}
+
+// From keccak-p[n. b_r] state bit string, extracting first 256 -bits
+// as output digest of SHA3-256 2-to-1 hasher
+void
+prepare_digest_bytes(std::bitset<1600>& s, sycl::uchar* const out)
+{
+  size_t s_idx = 1599;
+
+  for (size_t i = 0; i < 32; i++) {
+    *(out + i) = set_bit_at<0>(s[s_idx--]) | set_bit_at<1>(s[s_idx--]) |
+                 set_bit_at<2>(s[s_idx--]) | set_bit_at<3>(s[s_idx--]) |
+                 set_bit_at<4>(s[s_idx--]) | set_bit_at<5>(s[s_idx--]) |
+                 set_bit_at<6>(s[s_idx--]) | set_bit_at<7>(s[s_idx--]);
+  }
 }
 
 }

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include "sha3.hpp"
+
+namespace sha3_256 {
+
+// Given two ( byte concatenated ) SHA3-256 digests ( i.e. 64 -bytes ), prepares
+// bit string of length 1600, which can be passed to keccak_p[b, n_r]
+// permutation function, in later phase
+void
+prepare_bit_string(sycl::uchar* const in, std::bitset<1600>& s)
+{
+  s.reset();
+
+  size_t s_idx = 1599;
+  for (size_t i = 0; i < 64; i++) {
+    s[s_idx--] = bit_at<0>(*(in + i));
+    s[s_idx--] = bit_at<1>(*(in + i));
+    s[s_idx--] = bit_at<2>(*(in + i));
+    s[s_idx--] = bit_at<3>(*(in + i));
+    s[s_idx--] = bit_at<4>(*(in + i));
+    s[s_idx--] = bit_at<5>(*(in + i));
+    s[s_idx--] = bit_at<6>(*(in + i));
+    s[s_idx--] = bit_at<7>(*(in + i));
+  }
+
+  s[s_idx--] = 0;
+  s[s_idx--] = 1;
+
+  s[s_idx--] = 1;
+  for (size_t i = 0; i < pad(1088, 514); i++) {
+    s[s_idx--] = 0;
+  }
+  s[s_idx--] = 1;
+}
+
+}

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -3,6 +3,14 @@
 
 namespace sha3_256 {
 
+// SHA3-256 specific input/ output width constants, taken from
+// table 4's in section A.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+constexpr size_t IN_LEN_BITS = 512;
+constexpr size_t IN_LEN_BYTES = IN_LEN_BITS >> 3;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
 // Given two ( byte concatenated ) SHA3-256 digests ( i.e. 64 -bytes ), prepares
 // bit string of length 1600, which can be passed to keccak_p[b, n_r]
 // permutation function, in later phase

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -48,4 +48,24 @@ prepare_digest_bytes(std::bitset<1600>& s, sycl::uchar* const out)
   }
 }
 
+// SHA3-256 2-to-1 hasher, where input is 64 contiguous bytes which is hashed
+// to produce 32 -bytes output
+//
+// This function itself doesn't do much instead of calling other functions
+// which actually
+// - prepares state bit array from input byte array
+// - permutes input using `keccak-p[b, n_r]`
+// - truncates first 256 -bits from state bit array
+//
+// See section 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+void
+hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
+{
+  std::bitset<1600> s;
+
+  prepare_bit_string(in, s);
+  keccak_p(s);
+  prepare_digest_bytes(s, digest);
+}
+
 }

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -83,55 +83,6 @@ to_digest_bytes(const sycl::ulong* __restrict in,
   }
 }
 
-// Given two ( byte concatenated ) SHA3-256 digests ( i.e. 64 -bytes ), prepares
-// bit string of length 1600, which can be passed to keccak_p[b, n_r]
-// permutation function, in later phase
-//
-// See algorithm 10 ( h2b ) defined in section B.1 of
-// http://dx.doi.org/10.6028/NIST.FIPS.202
-void
-prepare_bit_string(const sycl::uchar* in, std::bitset<1600>& s)
-{
-  s.reset();
-
-  size_t s_idx = 1599;
-  for (size_t i = 0; i < 64; i++) {
-    s[s_idx--] = get_bit_at<0>(*(in + i));
-    s[s_idx--] = get_bit_at<1>(*(in + i));
-    s[s_idx--] = get_bit_at<2>(*(in + i));
-    s[s_idx--] = get_bit_at<3>(*(in + i));
-    s[s_idx--] = get_bit_at<4>(*(in + i));
-    s[s_idx--] = get_bit_at<5>(*(in + i));
-    s[s_idx--] = get_bit_at<6>(*(in + i));
-    s[s_idx--] = get_bit_at<7>(*(in + i));
-  }
-
-  s[s_idx--] = 0;
-  s[s_idx--] = 1;
-
-  s[s_idx--] = 1;
-  for (size_t i = 0; i < 572; i++) {
-    s[s_idx--] = 0;
-  }
-  s[s_idx--] = 1;
-}
-
-// From keccak-p[n. b_r] state bit string, extracting first 256 -bits
-// as output digest of SHA3-256 2-to-1 hasher
-void
-prepare_digest_bytes(std::bitset<1600>& s, sycl::uchar* const out)
-{
-  size_t s_idx = 1599;
-
-  for (size_t i = 0; i < 32; i++) {
-    *(out + i) = set_bit_at<7>(s[s_idx - 7]) | set_bit_at<6>(s[s_idx - 6]) |
-                 set_bit_at<5>(s[s_idx - 5]) | set_bit_at<4>(s[s_idx - 4]) |
-                 set_bit_at<3>(s[s_idx - 3]) | set_bit_at<2>(s[s_idx - 2]) |
-                 set_bit_at<1>(s[s_idx - 1]) | set_bit_at<0>(s[s_idx - 0]);
-    s_idx -= 8;
-  }
-}
-
 // SHA3-256 2-to-1 hasher, where input is 64 contiguous bytes which is hashed
 // to produce 32 -bytes output
 //
@@ -145,11 +96,11 @@ prepare_digest_bytes(std::bitset<1600>& s, sycl::uchar* const out)
 void
 hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
 {
-  std::bitset<1600> s;
+  sycl::ulong state[25];
 
-  prepare_bit_string(in, s);
-  keccak_p(s);
-  prepare_digest_bytes(s, digest);
+  to_state_array(in, state);
+  keccak_p(state);
+  to_digest_bytes(state, digest);
 }
 
 }

--- a/include/sha3_256.hpp
+++ b/include/sha3_256.hpp
@@ -6,6 +6,9 @@ namespace sha3_256 {
 // Given two ( byte concatenated ) SHA3-256 digests ( i.e. 64 -bytes ), prepares
 // bit string of length 1600, which can be passed to keccak_p[b, n_r]
 // permutation function, in later phase
+//
+// See algorithm 10 ( h2b ) defined in section B.1 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202
 void
 prepare_bit_string(const sycl::uchar* in, std::bitset<1600>& s)
 {
@@ -27,7 +30,7 @@ prepare_bit_string(const sycl::uchar* in, std::bitset<1600>& s)
   s[s_idx--] = 1;
 
   s[s_idx--] = 1;
-  for (size_t i = 0; i < pad(1088, 514); i++) {
+  for (size_t i = 0; i < 572; i++) {
     s[s_idx--] = 0;
   }
   s[s_idx--] = 1;
@@ -41,10 +44,11 @@ prepare_digest_bytes(std::bitset<1600>& s, sycl::uchar* const out)
   size_t s_idx = 1599;
 
   for (size_t i = 0; i < 32; i++) {
-    *(out + i) = set_bit_at<0>(s[s_idx--]) | set_bit_at<1>(s[s_idx--]) |
-                 set_bit_at<2>(s[s_idx--]) | set_bit_at<3>(s[s_idx--]) |
-                 set_bit_at<4>(s[s_idx--]) | set_bit_at<5>(s[s_idx--]) |
-                 set_bit_at<6>(s[s_idx--]) | set_bit_at<7>(s[s_idx--]);
+    *(out + i) = set_bit_at<7>(s[s_idx - 7]) | set_bit_at<6>(s[s_idx - 6]) |
+                 set_bit_at<5>(s[s_idx - 5]) | set_bit_at<4>(s[s_idx - 4]) |
+                 set_bit_at<3>(s[s_idx - 3]) | set_bit_at<2>(s[s_idx - 2]) |
+                 set_bit_at<1>(s[s_idx - 1]) | set_bit_at<0>(s[s_idx - 0]);
+    s_idx -= 8;
   }
 }
 

--- a/include/sha3_384.hpp
+++ b/include/sha3_384.hpp
@@ -1,0 +1,96 @@
+#pragma once
+#include "sha3.hpp"
+
+namespace sha3_384 {
+
+// SHA3-384 specific input/ output width constants, taken from
+// table 4's in section A.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+constexpr size_t IN_LEN_BITS = 768;
+constexpr size_t IN_LEN_BYTES = IN_LEN_BITS >> 3;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+// From input byte array ( = 96 bytes ) preparing 5 x 5 x 64 keccak state array
+// as twenty five 64 -bit unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+void
+to_state_array(const sycl::uchar* __restrict in,
+               sycl::ulong* const __restrict state)
+{
+#pragma unroll 6
+  for (size_t i = 0; i < (IN_LEN_BYTES >> 3); i++) {
+    state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+               static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+               static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+               static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+               static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+               static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+               static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+               static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+  }
+
+  // see how 0b01 is appended to input message bits in section
+  // 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+  //
+  // also see padding requirement ( pad10*1 ) written in section 5.1 of
+  // http://dx.doi.org/10.6028/NIST.FIPS.202
+  //
+  // ! read right to left !
+  //
+  // = 0b1000000000000000000000000000000000000000000000000000000000000110
+  state[12] = 9223372036854775814ull;
+
+#pragma unroll 6
+  for (size_t i = 13; i < 25; i++) {
+    state[i] = 0ull;
+  }
+}
+
+// From absorbed hash state array of dimension 5 x 5 x 64, produces 48 -bytes
+// digest using method defined in section 3.1.3 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
+// B.1 of above hyperlinked document
+void
+to_digest_bytes(const sycl::ulong* __restrict in,
+                sycl::uchar* const __restrict digest)
+{
+#pragma unroll 3
+  for (size_t i = 0; i < 6; i++) {
+    const sycl::ulong lane = in[i];
+
+    digest[(i << 3) + 0] = static_cast<sycl::uchar>((lane >> 0) & 0xffull);
+    digest[(i << 3) + 1] = static_cast<sycl::uchar>((lane >> 8) & 0xffull);
+    digest[(i << 3) + 2] = static_cast<sycl::uchar>((lane >> 16) & 0xffull);
+    digest[(i << 3) + 3] = static_cast<sycl::uchar>((lane >> 24) & 0xffull);
+    digest[(i << 3) + 4] = static_cast<sycl::uchar>((lane >> 32) & 0xffull);
+    digest[(i << 3) + 5] = static_cast<sycl::uchar>((lane >> 40) & 0xffull);
+    digest[(i << 3) + 6] = static_cast<sycl::uchar>((lane >> 48) & 0xffull);
+    digest[(i << 3) + 7] = static_cast<sycl::uchar>((lane >> 56) & 0xffull);
+  }
+}
+
+// SHA3-384 2-to-1 hasher, where input is 96 contiguous bytes which is hashed
+// to produce 48 -bytes output
+//
+// This function itself doesn't do much instead of calling other functions
+// which actually
+// - prepares state bit array from input byte array
+// - permutes input using `keccak-p[b, n_r]`
+// - truncates first 224 -bits from state bit array
+//
+// See section 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+void
+hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
+{
+  sycl::ulong state[25];
+
+  to_state_array(in, state);
+  keccak_p(state);
+  to_digest_bytes(state, digest);
+}
+
+}

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -1,0 +1,163 @@
+#pragma once
+#include "sha3.hpp"
+
+namespace sha3_512 {
+
+// SHA3-512 specific input/ output width constants, taken from
+// table 4's in section A.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+constexpr size_t IN_LEN_BITS = 1024;
+constexpr size_t IN_LEN_BYTES = IN_LEN_BITS >> 3;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+constexpr size_t RATE_LEN_BITS = 576;
+constexpr size_t RATE_LEN_BYTES = RATE_LEN_BITS >> 3;
+
+// First absorb starting 576 -bits ( = 72 -bytes, note this is RATE for SHA3-512
+// ) of input byte array ( = 128 bytes ) preparing 5 x 5 x 64 keccak state array
+// as twenty five 64 -bit unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+//
+// Note total input is 1024 -bits wide
+void
+process_first_576_bits(const sycl::uchar* __restrict in,
+                       sycl::ulong* const __restrict state)
+{
+#pragma unroll 3
+  for (size_t i = 0; i < (RATE_LEN_BYTES >> 3); i++) {
+    state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+               static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+               static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+               static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+               static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+               static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+               static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+               static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+  }
+
+  // finally 1024 ( = capacity ) zero bits
+#pragma unroll 8
+  for (size_t i = 9; i < 25; i++) {
+    state[i] = 0ull;
+  }
+}
+
+// Then absorb remaining 448 -bits ( = 56 -bytes ) of input byte array ( = 128
+// -bytes ) preparing 5 x 6 x 64 keccak state array as twenty five 64 -bit
+// unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+//
+// Note total input is 1024 -bits wide
+void
+process_remaining_448_bits(const sycl::uchar* __restrict in,
+                           sycl::ulong* const __restrict state)
+{
+#pragma unroll 7
+  for (size_t i = 0; i < ((IN_LEN_BITS - RATE_LEN_BITS) >> 6); i++) {
+    state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+               static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+               static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+               static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+               static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+               static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+               static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+               static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+  }
+
+  // following two write ops actually pushing
+  // 0b10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000110
+  // bit pattern ( read in opposite order i.e. right to left ascending )
+  // at end of 448 -bit input message bits
+  //
+  // = 0b0000000000000000000000000000000000000000000000000000000000000110
+  state[7] = 0b110ull;
+  // = 0b1000000000000000000000000000000000000000000000000000000000000000
+  // = 1 << 63
+  state[8] = 9223372036854775808ull;
+
+  // finally 1024 ( = capacity ) zero bits
+#pragma unroll 8
+  for (size_t i = 9; i < 25; i++) {
+    state[i] = 0ull;
+  }
+}
+
+// Because RATE is small enough ( = 576 -bits ) that I'm required to absorb
+// whole padded input bits in two phases, after performing keccak-p[b, n_r]
+// permutation on first 576 input -bits, before second permutation can be
+// applied for absorbing remaining 448 input -bits, I'm required to mix current
+// state array ( in size 5 x 5 x 64 ) with previous state array
+//
+// Note total input is 1024 -bits wide
+static inline void
+mix_prev_into_cur_state(const sycl::ulong* __restrict prev,
+                        sycl::ulong* const __restrict cur)
+{
+#pragma unroll 8
+  for (size_t i = 0; i < 24; i++) {
+    cur[i] ^= prev[i];
+  }
+
+  cur[24] ^= prev[24];
+}
+
+// From absorbed hash state array of dimension 5 x 5 x 64, produces 64 -bytes
+// digest using method defined in section 3.1.3 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
+// B.1 of above hyperlinked document
+void
+to_digest_bytes(const sycl::ulong* __restrict in,
+                sycl::uchar* const __restrict digest)
+{
+#pragma unroll 4
+  for (size_t i = 0; i < 8; i++) {
+    const sycl::ulong lane = in[i];
+
+    digest[(i << 3) + 0] = static_cast<sycl::uchar>((lane >> 0) & 0xffull);
+    digest[(i << 3) + 1] = static_cast<sycl::uchar>((lane >> 8) & 0xffull);
+    digest[(i << 3) + 2] = static_cast<sycl::uchar>((lane >> 16) & 0xffull);
+    digest[(i << 3) + 3] = static_cast<sycl::uchar>((lane >> 24) & 0xffull);
+    digest[(i << 3) + 4] = static_cast<sycl::uchar>((lane >> 32) & 0xffull);
+    digest[(i << 3) + 5] = static_cast<sycl::uchar>((lane >> 40) & 0xffull);
+    digest[(i << 3) + 6] = static_cast<sycl::uchar>((lane >> 48) & 0xffull);
+    digest[(i << 3) + 7] = static_cast<sycl::uchar>((lane >> 56) & 0xffull);
+  }
+}
+
+// SHA3-512 2-to-1 hasher, where input is 128 contiguous bytes which is hashed
+// to produce 64 -bytes output
+//
+// This function itself doesn't do much instead of calling other functions
+// which actually
+// - prepares state bit array from first 576 input bits
+// - permutes input using `keccak-p[b, n_r]`
+// - then prepares another state bit array from remaining 448 input bits
+// - mixes ( read XORs ) previous state bit array into current state bit array
+// - permutes current input bit array using `keccak-p[b, n_r]`
+// - truncates first 512 -bits from final state bit array
+//
+// See section 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+void
+hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
+{
+  sycl::ulong state_0[25];
+  sycl::ulong state_1[25];
+
+  process_first_576_bits(in, state_0);
+  keccak_p(state_0);
+
+  process_remaining_448_bits(in + 72, state_1);
+  mix_prev_into_cur_state(state_0, state_1);
+  keccak_p(state_1);
+
+  to_digest_bytes(state_1, digest);
+}
+
+}

--- a/include/test_sha3_224.hpp
+++ b/include/test_sha3_224.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include "sha3_224.hpp"
+#include <cassert>
+
+void
+test_sha3_224(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_224(bytes([i for i in range(56)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[28] = { 252, 149, 212, 78,  128, 108, 187,
+                                         212, 132, 227, 121, 136, 34,  56,
+                                         245, 85,  253, 169, 35,  135, 140,
+                                         68,  58,  190, 76,  228, 205, 214 };
+
+  // acquire resources
+  sycl::uchar* in = static_cast<sycl::uchar*>(sycl::malloc_shared(56, q));
+  sycl::uchar* out = static_cast<sycl::uchar*>(sycl::malloc_shared(28, q));
+
+#pragma unroll 8
+  for (size_t i = 0; i < 56; i++) {
+    // preparing input for testing 2-to-1 SHA3-224 hash
+    *(in + i) = i;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA3_224>([=]() { sha3_224::hash(in, out); });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 28; i++) {
+    assert(*(out + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in, q);
+  sycl::free(out, q);
+}

--- a/include/test_sha3_256.hpp
+++ b/include/test_sha3_256.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include "sha3_256.hpp"
+#include <cassert>
+
+void
+test_sha3_256(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_256(bytes([i for i in range(64)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[32] = { 200, 173, 71,  143, 78,  29,  217, 212,
+                                         125, 252, 59,  152, 87,  8,   217, 45,
+                                         177, 248, 219, 72,  254, 156, 221, 212,
+                                         89,  230, 60,  50,  31,  73,  4,   2 };
+
+  // acquire resources
+  sycl::uchar* in = static_cast<sycl::uchar*>(sycl::malloc_shared(64, q));
+  sycl::uchar* out = static_cast<sycl::uchar*>(sycl::malloc_shared(32, q));
+
+#pragma unroll 16
+  for (size_t i = 0; i < 64; i++) {
+    // preparing input for testing 2-to-1 SHA3-256 hash
+    *(in + i) = i;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA3_256>([=]() { sha3_256::hash(in, out); });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 32; i++) {
+    assert(*(out + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in, q);
+  sycl::free(out, q);
+}

--- a/include/test_sha3_384.hpp
+++ b/include/test_sha3_384.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include "sha3_384.hpp"
+#include <cassert>
+
+void
+test_sha3_384(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_384(bytes([i for i in range(96)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[48] = {
+    214, 226, 102, 151, 10,  63,  220, 212, 168, 51,  218, 134,
+    21,  153, 23,  154, 6,   11,  87,  105, 89,  233, 147, 180,
+    105, 133, 41,  48,  78,  227, 140, 35,  199, 16,  42,  112,
+    132, 196, 213, 104, 177, 217, 85,  35,  209, 64,  119, 231
+  };
+
+  // acquire resources
+  sycl::uchar* in = static_cast<sycl::uchar*>(sycl::malloc_shared(96, q));
+  sycl::uchar* out = static_cast<sycl::uchar*>(sycl::malloc_shared(48, q));
+
+#pragma unroll 16
+  for (size_t i = 0; i < 96; i++) {
+    // preparing input for testing 2-to-1 SHA3-384 hash
+    *(in + i) = i;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA3_384>([=]() { sha3_384::hash(in, out); });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 48; i++) {
+    assert(*(out + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in, q);
+  sycl::free(out, q);
+}

--- a/include/test_sha3_512.hpp
+++ b/include/test_sha3_512.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "sha3_512.hpp"
+#include <cassert>
+
+void
+test_sha3_512(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_512(bytes([i for i in range(128)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[64] = {
+    152, 156, 25,  149, 218, 157, 45,  52,  31,  153, 60,  46,  44,
+    166, 149, 243, 71,  112, 117, 6,   27,  251, 210, 205, 240, 190,
+    117, 207, 123, 169, 159, 190, 51,  216, 210, 196, 220, 195, 31,
+    168, 153, 23,  120, 107, 136, 62,  108, 157, 91,  2,   237, 129,
+    183, 72,  58,  76,  179, 234, 152, 103, 21,  136, 247, 69
+  };
+
+  // acquire resources
+  sycl::uchar* in = static_cast<sycl::uchar*>(sycl::malloc_shared(128, q));
+  sycl::uchar* out = static_cast<sycl::uchar*>(sycl::malloc_shared(64, q));
+
+#pragma unroll 16
+  for (size_t i = 0; i < 128; i++) {
+    // preparing input for testing 2-to-1 SHA3-512 hash
+    *(in + i) = i;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA3_512>([=]() { sha3_512::hash(in, out); });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 64; i++) {
+    assert(*(out + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in, q);
+  sycl::free(out, q);
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <CL/sycl.hpp>
-#include <bitset>
 
 // Circular right shift of 32 -bit word, by n bit places
 //
@@ -119,64 +118,4 @@ from_words_to_be_bytes(const sycl::ulong word, sycl::uchar* const out)
   *(out + 5) = static_cast<sycl::uchar>((word >> 16) & 0xff);
   *(out + 6) = static_cast<sycl::uchar>((word >> 8) & 0xff);
   *(out + 7) = static_cast<sycl::uchar>((word >> 0) & 0xff);
-}
-
-// Compile time check to ensure that template argument passed to bit lane
-// rotation function(s) is in allowed range ∈ [0, lane_size), lane_size = 64
-constexpr bool
-is_valid_rotation(const uint8_t n)
-{
-  return n >= 0 && n < 64;
-}
-
-// Circularly shift 64 -bit wide lane leftwards by `n` bit places
-// where n >= 0 && n < 64
-template<uint8_t pos>
-inline std::bitset<64>
-rotl(std::bitset<64>& a) requires(is_valid_rotation(pos))
-{
-  return (a << pos) | (a >> (64 - pos));
-}
-
-// Circularly shift 64 -bit wide lane rightwards by `n` bit places
-// where n >= 0 && n < 64
-template<uint8_t pos>
-inline std::bitset<64>
-rotr(std::bitset<64>& a) requires(is_valid_rotation(pos))
-{
-  return (a >> pos) | (a << (64 - pos));
-}
-
-// Modern C++ feature to compile-time ensure that template argument position,
-// passed to following `{get,set}_bit_at` routine ∈ [0, 8)
-constexpr bool
-is_valid_bit_pos(const uint8_t pos)
-{
-  return pos >= 0 && pos < 8;
-}
-
-// Extracts bit from one of 8 possible bit positions of a byte
-//
-// Bit position indexing is ascending right to left,
-// meaning if byte = 0b11110000,
-// then assert(byte[0] == 0 && byte[6] = 1)
-template<uint8_t pos>
-inline bool
-get_bit_at(sycl::uchar byte) requires(is_valid_bit_pos(pos))
-{
-  return (byte >> pos) & 0b1;
-}
-
-// Sets bit value at one of 8 possible bit positions in a byte
-//
-// Note indexing of bits in specified bytes is performed left to
-// right ascending order
-//
-// Meaning if byte = 0b11110000,
-// then assert(byte[0] == 1 && byte[7] = 0)
-template<uint8_t pos>
-inline sycl::uchar
-set_bit_at(bool bit) requires(is_valid_bit_pos(pos))
-{
-  return static_cast<sycl::uchar>(bit) << pos;
 }

--- a/results/sha3-224/intel_cpu.md
+++ b/results/sha3-224/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA3-224 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_224 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   441.313146 ms                     2.828693 ms                     3.067447 ms
+        2 ^ 21                   881.435162 ms                     5.918054 ms                     6.043629 ms
+        2 ^ 22                      1.759670 s                    11.524675 ms                    11.689306 ms
+        2 ^ 23                      3.525266 s                    24.145784 ms                    24.199104 ms
+        2 ^ 24                      7.043599 s                    47.596686 ms                    47.643860 ms
+        2 ^ 25                     14.165549 s                    95.153863 ms                  
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    13.079599 ms                     1.354843 ms                     1.179845 ms
+        2 ^ 21                    20.786925 ms                     3.279467 ms                     1.921304 ms
+        2 ^ 22                    33.636769 ms                     5.938975 ms                     3.739403 ms
+        2 ^ 23                    60.527577 ms                    10.275394 ms                     3.634558 ms
+        2 ^ 24                   116.507279 ms                    16.135763 ms                     7.115856 ms
+        2 ^ 25                   231.727947 ms                    23.140918 ms                    13.985500 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    30.821758 ms                     1.291234 ms                   710.533125 us
+        2 ^ 21                    60.974097 ms                     2.444916 ms                     1.493359 ms
+        2 ^ 22                   117.379986 ms                     4.960545 ms                     2.851427 ms
+        2 ^ 23                   230.460750 ms                     8.972397 ms                     5.574060 ms
+        2 ^ 24                   458.509651 ms                    15.732812 ms                    11.348903 ms
+        2 ^ 25                   938.098973 ms                    54.020292 ms                    23.115493 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    26.285759 ms                   832.090875 us                   795.686250 us
+        2 ^ 21                    52.246320 ms                     1.766923 ms                     1.696765 ms
+        2 ^ 22                   105.391437 ms                     3.529938 ms                     3.430882 ms
+        2 ^ 23                   205.738750 ms                     7.184241 ms                     7.062021 ms
+        2 ^ 24                   410.537958 ms                    14.054861 ms                    13.946278 ms
+        2 ^ 25                   819.288981 ms                    27.466327 ms                    27.053277 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    69.412657 ms                   795.589500 us                   727.804125 us
+        2 ^ 21                   115.531715 ms                     1.561098 ms                     1.514993 ms
+        2 ^ 22                   229.142733 ms                     3.169098 ms                     3.031581 ms
+        2 ^ 23                   458.677792 ms                     6.097932 ms                     6.134698 ms
+        2 ^ 24                   915.077926 ms                    12.123231 ms                    12.139003 ms
+        2 ^ 25                      2.003310 s                    24.247329 ms                    24.197952 ms
+```

--- a/results/sha3-224/intel_gpu.md
+++ b/results/sha3-224/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHA3-224 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_224 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    25.223484 ms                     2.909517 ms                     1.943604 ms
+        2 ^ 21                    48.836151 ms                     5.816285 ms                     3.879427 ms
+        2 ^ 22                    95.447547 ms                    11.645907 ms                     7.751796 ms
+        2 ^ 23                   187.926882 ms                    23.257689 ms                    15.500472 ms
+        2 ^ 24                   373.580415 ms                    46.510990 ms                    30.994879 ms
+        2 ^ 25                   744.879213 ms                    92.975356 ms                    61.980399 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   106.771200 ms                     1.167934 ms                   652.068750 us
+        2 ^ 21                   211.127162 ms                     1.298971 ms                     1.234853 ms
+        2 ^ 22                   419.490985 ms                     2.499773 ms                     2.436278 ms
+        2 ^ 23                   836.673428 ms                     4.903121 ms                     4.823504 ms
+        2 ^ 24                      1.669896 s                     9.690955 ms                     9.642774 ms
+        2 ^ 25                      3.337676 s                    19.390999 ms                    19.220123 ms
+```

--- a/results/sha3-224/nvidia_gpu.md
+++ b/results/sha3-224/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-224 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha3_224 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA3-224
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   655.746375 us                     1.021944 ms                   879.684375 us
+        2 ^ 21                     1.156266 ms                     2.024460 ms                     1.757996 ms
+        2 ^ 22                     2.138489 ms                     4.021912 ms                     3.513062 ms
+        2 ^ 23                     4.088013 ms                     8.028900 ms                     7.030884 ms
+        2 ^ 24                     7.960693 ms                    16.006165 ms                    14.053711 ms
+        2 ^ 25                    13.526733 ms                    31.978638 ms                    28.107422 ms
+```

--- a/results/sha3-256/intel_cpu.md
+++ b/results/sha3-256/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA3-256 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_256 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   460.527613 ms                     3.378705 ms                     3.513406 ms
+        2 ^ 21                   884.408269 ms                     6.608696 ms                     6.680540 ms
+        2 ^ 22                      1.750542 s                    13.186952 ms                    13.351823 ms
+        2 ^ 23                      3.498270 s                    27.775797 ms                    27.589655 ms
+        2 ^ 24                      7.032438 s                    54.475082 ms                    54.506723 ms
+        2 ^ 25                     14.041351 s                   107.947459 ms                   109.120553 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    24.213955 ms                     2.099417 ms                     1.147591 ms
+        2 ^ 21                    62.796379 ms                     3.296168 ms                     2.220697 ms
+        2 ^ 22                    33.891272 ms                     6.672769 ms                     4.235582 ms
+        2 ^ 23                    59.978552 ms                    12.807243 ms                     4.105317 ms
+        2 ^ 24                   117.749699 ms                    17.167419 ms                     7.970099 ms
+        2 ^ 25                   234.548106 ms                    25.114616 ms                    15.699562 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    33.152645 ms                     1.682082 ms                   796.108500 us
+        2 ^ 21                    65.376513 ms                     2.994367 ms                     1.589848 ms
+        2 ^ 22                   117.765811 ms                     5.919532 ms                    11.558829 ms
+        2 ^ 23                   231.303439 ms                     9.850140 ms                    15.033037 ms
+        2 ^ 24                   461.649286 ms                    25.151985 ms                    12.094869 ms
+        2 ^ 25                   922.339764 ms                    34.289637 ms                    26.320650 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    26.406774 ms                     1.258974 ms                   935.372625 us
+        2 ^ 21                    52.468677 ms                     2.075004 ms                     2.027945 ms
+        2 ^ 22                   104.464652 ms                     4.209483 ms                     4.136641 ms
+        2 ^ 23                   205.639685 ms                     8.374299 ms                     8.174240 ms
+        2 ^ 24                   409.958382 ms                    16.108984 ms                    15.956122 ms
+        2 ^ 25                   818.950744 ms                    32.119388 ms                    31.103533 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    62.844377 ms                   912.211875 us                   841.460250 us
+        2 ^ 21                   117.112114 ms                     1.771213 ms                     1.703229 ms
+        2 ^ 22                   231.993665 ms                     3.471314 ms                     3.412241 ms
+        2 ^ 23                   463.345803 ms                     6.896977 ms                     8.071636 ms
+        2 ^ 24                   925.487535 ms                    14.186806 ms                    13.770779 ms
+        2 ^ 25                      2.019036 s                    27.535975 ms                    27.752319 ms
+```

--- a/results/sha3-256/intel_gpu.md
+++ b/results/sha3-256/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHA3-256 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_256 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    23.984610 ms                     3.324769 ms                     2.221226 ms
+        2 ^ 21                    46.259382 ms                     6.643864 ms                     4.436172 ms
+        2 ^ 22                    90.467286 ms                    13.314171 ms                     8.856666 ms
+        2 ^ 23                   178.541454 ms                    26.589966 ms                    17.714424 ms
+        2 ^ 24                   355.002453 ms                    53.145359 ms                    35.418396 ms
+        2 ^ 25                   707.377671 ms                   106.254076 ms                    70.831839 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   107.777160 ms                   768.600750 us                   711.330750 us
+        2 ^ 21                   213.150474 ms                     1.480429 ms                     1.442208 ms
+        2 ^ 22                   423.765941 ms                     2.861508 ms                     2.822228 ms
+        2 ^ 23                   844.021978 ms                     5.608974 ms                     5.555252 ms
+        2 ^ 24                      1.685802 s                    20.175661 ms                    11.154640 ms
+        2 ^ 25                      3.369420 s                    22.098626 ms                    22.164610 ms
+```

--- a/results/sha3-256/nvidia_gpu.md
+++ b/results/sha3-256/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-256 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha3_256 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA3-256
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   752.334750 us                     1.167084 ms                     1.005913 ms
+        2 ^ 21                     1.347657 ms                     2.312119 ms                     2.012466 ms
+        2 ^ 22                     2.526214 ms                     4.599151 ms                     4.014862 ms
+        2 ^ 23                     4.852661 ms                     9.173950 ms                     8.025696 ms
+        2 ^ 24                     8.640747 ms                    18.299194 ms                    16.064941 ms
+        2 ^ 25                    16.185790 ms                    36.593994 ms                    32.170166 ms
+```

--- a/results/sha3-384/intel_cpu.md
+++ b/results/sha3-384/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA3-384 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_384 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   121.452534 ms                     5.250688 ms                     5.114491 ms
+        2 ^ 21                   242.495514 ms                     9.878091 ms                    10.002006 ms
+        2 ^ 22                   487.446581 ms                    20.749688 ms                    20.733140 ms
+        2 ^ 23                   968.630066 ms                    41.098545 ms                    40.908267 ms
+        2 ^ 24                      1.936018 s                    81.650025 ms                    81.427060 ms
+        2 ^ 25                      3.877924 s                   163.935222 ms                   164.065617 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     5.484831 ms                     1.799175 ms                     2.268806 ms
+        2 ^ 21                     6.861796 ms                     6.618026 ms                     1.753305 ms
+        2 ^ 22                     9.038283 ms                    10.856676 ms                     3.195043 ms
+        2 ^ 23                    15.615609 ms                    14.961957 ms                     6.015195 ms
+        2 ^ 24                    30.814614 ms                    21.000240 ms                    11.727313 ms
+        2 ^ 25                    61.229065 ms                    39.717597 ms                    23.346449 m
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    10.222366 ms                     2.462541 ms                     1.604796 ms
+        2 ^ 21                    15.848323 ms                     4.915875 ms                     2.600809 ms
+        2 ^ 22                    27.781493 ms                     8.892203 ms                     4.878789 ms
+        2 ^ 23                    54.174604 ms                    13.766896 ms                     9.307206 ms
+        2 ^ 24                   107.784253 ms                    36.425805 ms                    19.862340 ms
+        2 ^ 25                   215.203138 ms                    68.672697 ms                    42.242766 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     9.466639 ms                     1.528539 ms                     1.410706 ms
+        2 ^ 21                    14.855669 ms                     3.009892 ms                     2.942806 ms
+        2 ^ 22                    27.278380 ms                     7.817085 ms                     5.957917 ms
+        2 ^ 23                    53.826366 ms                    12.126587 ms                    11.938260 ms
+        2 ^ 24                   107.146426 ms                    24.175173 ms                    23.971688 ms
+        2 ^ 25                   213.836448 ms                    47.514487 ms                    46.691987 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    21.584894 ms                     1.336357 ms                     1.312938 ms
+        2 ^ 21                    43.433253 ms                     2.638164 ms                     2.592325 ms
+        2 ^ 22                    86.769447 ms                     5.188149 ms                     5.138226 ms
+        2 ^ 23                   170.747419 ms                    10.330659 ms                    10.343127 ms
+        2 ^ 24                   340.255293 ms                    20.730265 ms                    20.627062 ms
+        2 ^ 25                   680.419022 ms                    41.408275 ms                    41.222121 ms
+```

--- a/results/sha3-384/intel_gpu.md
+++ b/results/sha3-384/intel_gpu.md
@@ -1,0 +1,41 @@
+### Binary Merklization using SHA3-384 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_384 make aot_gpu
+```
+
+### On `Intel(R) Iris(R) Xe MAX Graphics [0x4905]`
+
+```bash
+running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    26.168610 ms                     4.986228 ms                     3.323404 ms
+        2 ^ 21                    50.483082 ms                     9.982226 ms                     6.647920 ms
+        2 ^ 22                    98.915973 ms                    19.956007 ms                    13.281021 ms
+        2 ^ 23                   195.430248 ms                    39.864279 ms                    26.563836 ms
+        2 ^ 24                   388.282635 ms                    79.700069 ms                    53.124162 ms
+        2 ^ 25                   773.846658 ms                   159.363769 ms                   106.251229 ms
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   113.338949 ms                     1.135689 ms                     1.077983 ms
+        2 ^ 21                   224.178310 ms                     4.001492 ms                     2.097452 ms
+        2 ^ 22                   445.379515 ms                     4.231070 ms                     4.163218 ms
+        2 ^ 23                   888.437042 ms                     8.346355 ms                     8.339944 ms
+        2 ^ 24                      1.773451 s                    16.782476 ms                    16.473902 ms
+        2 ^ 25                      3.544434 s                    32.968222 ms                    33.054750 ms
+```

--- a/results/sha3-384/nvidia_gpu.md
+++ b/results/sha3-384/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-384 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha3_384 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA3-384
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   999.549375 us                     1.739604 ms                     1.508103 ms
+        2 ^ 21                     1.821351 ms                     3.455978 ms                     3.011856 ms
+        2 ^ 22                     3.385437 ms                     6.848968 ms                     6.024078 ms
+        2 ^ 23                     6.186218 ms                    13.745361 ms                    12.038086 ms
+        2 ^ 24                    10.959961 ms                    27.432861 ms                    24.085327 ms
+        2 ^ 25                    21.593261 ms                    54.867188 ms                    48.198486 ms
+```

--- a/results/sha3-512/intel_cpu.md
+++ b/results/sha3-512/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA3-512 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_512 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                      1.422096 s                     6.655711 ms                     6.632538 ms
+        2 ^ 21                      2.826801 s                    13.003300 ms                    13.222868 ms
+        2 ^ 22                      5.655653 s                    27.421870 ms                    27.016023 ms
+        2 ^ 23                     11.310605 s                    53.933905 ms                    54.153294 ms
+        2 ^ 24                     23.166480 s                   107.621708 ms                   108.141864 ms
+        2 ^ 25                     46.915646 s                   215.222096 ms                   223.990513 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    18.212837 ms                     3.521151 ms                     1.154891 ms
+        2 ^ 21                    31.598131 ms                     8.554403 ms                     4.468314 ms
+        2 ^ 22                    57.098150 ms                    13.102806 ms                     4.367535 ms
+        2 ^ 23                   112.831001 ms                    17.162144 ms                     8.644232 ms
+        2 ^ 24                   222.342946 ms                    25.501501 ms                    17.274517 ms
+        2 ^ 25                   442.875605 ms                    51.969265 ms                    33.731850 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    83.168826 ms                     3.148146 ms                     1.616418 ms
+        2 ^ 21                   118.585412 ms                     5.744802 ms                     3.080455 ms
+        2 ^ 22                   232.349992 ms                    10.116922 ms                     6.071552 ms
+        2 ^ 23                   463.172213 ms                    17.845495 ms                    12.323518 ms
+        2 ^ 24                   924.780638 ms                    35.928981 ms                    26.567100 ms
+        2 ^ 25                      1.853150 s                    92.435423 ms                    54.594908 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    55.401972 ms                     2.028286 ms                     1.841675 ms
+        2 ^ 21                   104.913798 ms                     4.298537 ms                     3.958525 ms
+        2 ^ 22                   204.813210 ms                     8.176016 ms                     7.942972 ms
+        2 ^ 23                   407.979027 ms                    16.235003 ms                    15.930501 ms
+        2 ^ 24                   815.037735 ms                    31.475015 ms                    31.085153 ms
+        2 ^ 25                      1.644981 s                    62.561881 ms                    62.212671 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   203.357929 ms                     1.772444 ms                     1.711588 ms
+        2 ^ 21                   405.166609 ms                     3.473879 ms                     3.392248 ms
+        2 ^ 22                   809.711764 ms                     6.936534 ms                     6.848052 ms
+        2 ^ 23                      1.735337 s                    13.794764 ms                    13.937174 ms
+        2 ^ 24                      3.465506 s                    27.510037 ms                    27.550688 ms
+        2 ^ 25                      6.932260 s                    55.162014 ms                    54.967118 ms
+```

--- a/results/sha3-512/intel_gpu.md
+++ b/results/sha3-512/intel_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-512 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_512 make aot_gpu
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   289.603807 ms                     1.504084 ms                     1.416810 ms
+        2 ^ 21                   576.084968 ms                     2.882175 ms                     2.812580 ms
+        2 ^ 22                      1.148452 s                     5.658525 ms                     5.527675 ms
+        2 ^ 23                      2.294983 s                    11.162608 ms                    11.004991 ms
+        2 ^ 24                      4.582099 s                    22.103979 ms                    21.868923 ms
+        2 ^ 25                      9.163329 s                    43.960825 ms                    44.113151 ms
+```

--- a/results/sha3-512/nvidia_gpu.md
+++ b/results/sha3-512/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-512 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha3_512 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.764427 ms                     2.308462 ms                     2.009170 ms
+        2 ^ 21                     3.197203 ms                     4.596451 ms                     4.014771 ms
+        2 ^ 22                     5.991760 ms                     9.152618 ms                     8.026062 ms
+        2 ^ 23                     9.980712 ms                    18.291870 ms                    16.050659 ms
+        2 ^ 24                    19.426758 ms                    36.573853 ms                    32.111572 ms
+        2 ^ 25                    38.345214 ms                    73.152832 ms                    64.349121 ms
+```

--- a/run.sh
+++ b/run.sh
@@ -4,13 +4,19 @@
 
 make clean
 
+# SHA1 related tests
 SHA=sha1         make; make clean
+
+# SHA2 related tests
 SHA=sha2_224     make; make clean
 SHA=sha2_256     make; make clean
 SHA=sha2_384     make; make clean
 SHA=sha2_512     make; make clean
 SHA=sha2_512_224 make; make clean
 SHA=sha2_512_256 make; make clean
-SHA=sha3_256 make; make clean
-SHA=sha3_224 make; make clean
-SHA=sha3_384 make; make clean
+
+# SHA3 related tests
+SHA=sha3_256     make; make clean
+SHA=sha3_224     make; make clean
+SHA=sha3_384     make; make clean
+SHA=sha3_512     make; make clean

--- a/run.sh
+++ b/run.sh
@@ -13,3 +13,4 @@ SHA=sha2_512_224 make; make clean
 SHA=sha2_512_256 make; make clean
 SHA=sha3_256 make; make clean
 SHA=sha3_224 make; make clean
+SHA=sha3_384 make; make clean

--- a/run.sh
+++ b/run.sh
@@ -11,3 +11,4 @@ SHA=sha2_384     make; make clean
 SHA=sha2_512     make; make clean
 SHA=sha2_512_224 make; make clean
 SHA=sha2_512_256 make; make clean
+SHA=sha3_256 make; make clean

--- a/run.sh
+++ b/run.sh
@@ -12,3 +12,4 @@ SHA=sha2_512     make; make clean
 SHA=sha2_512_224 make; make clean
 SHA=sha2_512_256 make; make clean
 SHA=sha3_256 make; make clean
+SHA=sha3_224 make; make clean

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -17,6 +17,8 @@
 #include "test_sha2_512_256.hpp"
 #elif defined SHA3_256
 #include "test_sha3_256.hpp"
+#elif defined SHA3_224
+#include "test_sha3_224.hpp"
 #endif
 
 int
@@ -72,6 +74,11 @@ main(int argc, char** argv)
   test_sha3_256(q);
   std::cout << "passed SHA3-256 test !" << std::endl;
 
+#elif defined SHA3_224
+
+  test_sha3_224(q);
+  std::cout << "passed SHA3-224 test !" << std::endl;
+
 #endif
 
   test_merklize(q);
@@ -98,6 +105,9 @@ main(int argc, char** argv)
             << std::endl;
 #elif defined SHA3_256
   std::cout << "passed binary merklization ( using SHA3-256 ) test !"
+            << std::endl;
+#elif defined SHA3_224
+  std::cout << "passed binary merklization ( using SHA3-224 ) test !"
             << std::endl;
 #endif
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,6 +21,8 @@
 #include "test_sha3_224.hpp"
 #elif defined SHA3_384
 #include "test_sha3_384.hpp"
+#elif defined SHA3_512
+#include "test_sha3_512.hpp"
 #endif
 
 int
@@ -86,6 +88,11 @@ main(int argc, char** argv)
   test_sha3_384(q);
   std::cout << "passed SHA3-384 test !" << std::endl;
 
+#elif defined SHA3_512
+
+  test_sha3_512(q);
+  std::cout << "passed SHA3-512 test !" << std::endl;
+
 #endif
 
   test_merklize(q);
@@ -118,6 +125,9 @@ main(int argc, char** argv)
             << std::endl;
 #elif defined SHA3_384
   std::cout << "passed binary merklization ( using SHA3-384 ) test !"
+            << std::endl;
+#elif defined SHA3_512
+  std::cout << "passed binary merklization ( using SHA3-512 ) test !"
             << std::endl;
 #endif
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -19,6 +19,8 @@
 #include "test_sha3_256.hpp"
 #elif defined SHA3_224
 #include "test_sha3_224.hpp"
+#elif defined SHA3_384
+#include "test_sha3_384.hpp"
 #endif
 
 int
@@ -79,6 +81,11 @@ main(int argc, char** argv)
   test_sha3_224(q);
   std::cout << "passed SHA3-224 test !" << std::endl;
 
+#elif defined SHA3_384
+
+  test_sha3_384(q);
+  std::cout << "passed SHA3-384 test !" << std::endl;
+
 #endif
 
   test_merklize(q);
@@ -108,6 +115,9 @@ main(int argc, char** argv)
             << std::endl;
 #elif defined SHA3_224
   std::cout << "passed binary merklization ( using SHA3-224 ) test !"
+            << std::endl;
+#elif defined SHA3_384
+  std::cout << "passed binary merklization ( using SHA3-384 ) test !"
             << std::endl;
 #endif
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -15,6 +15,8 @@
 #include "test_sha2_512_224.hpp"
 #elif defined SHA2_512_256
 #include "test_sha2_512_256.hpp"
+#elif defined SHA3_256
+#include "test_sha3_256.hpp"
 #endif
 
 int
@@ -65,6 +67,11 @@ main(int argc, char** argv)
   test_sha2_512_256(q);
   std::cout << "passed SHA2-512/256 test !" << std::endl;
 
+#elif defined SHA3_256
+
+  test_sha3_256(q);
+  std::cout << "passed SHA3-256 test !" << std::endl;
+
 #endif
 
   test_merklize(q);
@@ -88,6 +95,9 @@ main(int argc, char** argv)
             << std::endl;
 #elif defined SHA2_512_256
   std::cout << "passed binary merklization ( using SHA2-512/256 ) test !"
+            << std::endl;
+#elif defined SHA3_256
+  std::cout << "passed binary merklization ( using SHA3-256 ) test !"
             << std::endl;
 #endif
 


### PR DESCRIPTION
- Implement SHA3-256 -bit variant
- Write test cases for asserting that SHA3-256 works as expected
- Extend binary Merklization to use SHA3-256 as 2-to-1 hash function choice
- Extend benchmarking of binary merklization, along with that add relevant benchmark results 

## Results

### Binary Merklization

Leaf count | Accelerator | Execution Time
--- | --- | ---
2^25 | Tesla V100-SXM2-16GB | 16.185790 ms 
2 ^ 25 | Intel(R) Iris(R) Xe MAX Graphics | 707.377671 ms
2 ^ 25 | Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz [ 64 Cores ] | 234.548106 ms

See https://github.com/itzmeanjan/merklize-sha/tree/8ca89c16c2038a1da6a75f1568e87d4e48b74379/results/sha3-256