### PR TITLE
Implement SHA3-512

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SYCL accelerated Binary Merklization using SHA1, SHA2 & SHA3
 
 ## Motivation
 
-After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 & SHA3 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 & SHA3 families of cryptographic hash functions are data parallel, requiring to process each message block ( can be 512 -bit/ 1024 -bit ) sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2/ SHA3 families of cryptographic ( 2-to-1 ) hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
+After implementing BLAKE3 using SYCL, I decided to accelerate 2-to-1 hash implementation of all variants of SHA1, SHA2 & SHA3 families of cryptographic hash functions. BLAKE3 lends itself pretty well to parallelization efforts, due to its inherent data parallel friendly algorithmic construction, where each 1024 -bytes chunk can be compressed independently ( read parallelly ) and finally it's a binary merklization problem with compressed chunks as leaf nodes of binary merkle tree. But none of SHA1, SHA2 & SHA3 families of cryptographic hash functions are data parallel, requiring to process each message block ( can be 512 -bit/ 1024 -bit or padded to 1600 -bit in case of SHA3 family ) sequentially, which is why I only concentrated on accelerating Binary Merklization where SHA1/ SHA2/ SHA3 families of cryptographic ( 2-to-1 ) hash functions are used for computing all intermediate nodes of tree when N -many leaf nodes are provided, where `N = 2 ^ i | i = {1, 2, 3 ...}`. Each of these N -many leaf nodes are respective hash digests --- for example, when using SHA2-256 variant for computing all intermediate nodes of binary merkle tree, each of provided leaf node is 32 -bytes wide, representing a SHA2-256 digest. Now, N -many leaf digests are merged into N/ 2 -many digests which are intermediate nodes, living just above leaf nodes. Then in next phase, those N/ 2 -many intermediates are used for computing N/ 4 -many of intermediates which are living just above them. This process continues until root of merkle tree is computed. Notice, that in each level of tree, each consecutive pair of digests can be hashed independently --- and that's the scope of parallelism I'd like to make use of during binary merklization. In following depiction, when N ( = 4 ) nodes are provided as input, two intermediates can be computed in parallel and once they're computed root of tree can be computed as a single task.
 
 ```bash
   ((a, b), (c, d))          < --- [Level 1] [Root]
@@ -25,7 +25,7 @@ input   = [a, b, c, d]
 output  = [0, ((a, b), (c, d)), (a, b), (c, d)]
 ```
 
-Here in this repository, I'm keeping binary merklization kernels, implemented in SYCL, while using SHA1/ SHA2 variants as 2-to-1 hash function, which one to use is compile-time choice using pre-processor directive.
+Here in this repository, I'm keeping binary merklization kernels, implemented in SYCL, while using SHA1/ SHA2/ SHA3 variants as 2-to-1 hash function, which one to use is compile-time choice using pre-processor directive.
 
 If you happen to be interested in Binary Merklization using Rescue Prime Hash/ BLAKE3, consider seeing following links.
 
@@ -84,12 +84,16 @@ If you happen to be interested in 2-to-1 hash implementation of
 - [SHA2-512](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/example/sha2_512.cpp)
 - [SHA2-512/224](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/example/sha2_512_224.cpp)
 - [SHA2-512/256](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/example/sha2_512_256.cpp)
+- [SHA3-224](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_224.cpp)
+- [SHA3-256](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_256.cpp)
+- [SHA3-384](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_384.cpp)
+- [SHA3-512](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_512.cpp)
 
 where two digests of respective hash functions are input, in byte concatenated form, to `hash( ... )` function, consider taking a look at above hyperlinked examples.
 
 > Compile above examples using `dpcpp -fsycl example/<file>.cpp -I./include`
 
-You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/fd76b7a/include/merklize.hpp)
+You will probably like to see how binary merklization kernels use these 2-to-1 hash functions; see [here](https://github.com/itzmeanjan/merklize-sha/blob/4aadd99/include/merklize.hpp)
 
 ## Tests
 
@@ -137,5 +141,17 @@ I'm keeping binary merklization benchmark results of
   - [Nvidia GPU(s)](results/sha3-256/nvidia_gpu.md)
   - [Intel CPU(s)](results/sha3-256/intel_cpu.md)
   - [Intel GPU(s)](results/sha3-256/intel_gpu.md)
+- SHA3-224
+  - [Nvidia GPU(s)](results/sha3-224/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-224/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-224/intel_gpu.md)
+- SHA3-384
+  - [Nvidia GPU(s)](results/sha3-384/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-384/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-384/intel_gpu.md)
+- SHA3-512
+  - [Nvidia GPU(s)](results/sha3-512/nvidia_gpu.md)
+  - [Intel CPU(s)](results/sha3-512/intel_cpu.md)
+  - [Intel GPU(s)](results/sha3-512/intel_gpu.md)
 
 obtained after executing them on multiple accelerators.

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -70,6 +70,9 @@ main(int argc, char** argv)
 #elif defined SHA3_384
   std::cout << "\nBenchmarking Binary Merklization using SHA3-384" << std::endl
             << std::endl;
+#elif defined SHA3_512
+  std::cout << "\nBenchmarking Binary Merklization using SHA3-512" << std::endl
+            << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/example/sha3_256.cpp
+++ b/example/sha3_256.cpp
@@ -1,0 +1,68 @@
+#include "sha3_256.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA3-256 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 32
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[32] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 32
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[32] = { 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15 };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_256(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[32] = {
+    121, 136, 237, 222, 17, 197, 60,  82,  161, 87, 52,  66,  251, 235, 8,  125,
+    1,   95,  88,  134, 1,  235, 132, 182, 114, 55, 207, 202, 17,  104, 74, 95
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  // compute 2-to-1 hash
+  q.single_task<class kernelExampleSHA3_256>(
+    [=]() { sha3_256::hash(in, out); });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/example/sha3_384.cpp
+++ b/example/sha3_384.cpp
@@ -1,0 +1,72 @@
+#include "sha3_384.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA3-384 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 48
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[48] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 48
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[48] = { 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+                                         15, 15, 15, 15, 15, 15, 15, 15 };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_384(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[48] = {
+    25,  254, 93,  230, 2,  191, 78,  51,  238, 228, 239, 160,
+    231, 101, 38,  216, 38, 8,   135, 59,  34,  169, 154, 20,
+    221, 245, 50,  59,  27, 9,   21,  234, 249, 223, 45,  73,
+    214, 0,   146, 51,  25, 83,  0,   0,   111, 210, 47,  206
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  // compute 2-to-1 hash
+  q.single_task<class kernelExampleSHA3_384>(
+    [=]() { sha3_384::hash(in, out); });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/example/sha3_512.cpp
+++ b/example/sha3_512.cpp
@@ -1,0 +1,75 @@
+#include "sha3_512.hpp"
+#include <cassert>
+
+// This example attempts to show how to use 2-to-1 SHA3-512 hash function !
+int
+main(int argc, char** argv)
+{
+  // $ python3
+  // >>> a = [0xff] * 64
+  //
+  // first input digest
+  constexpr sycl::uchar digest_0[64] = {
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+  };
+
+  // >>> b = [0x0f] * 64
+  //
+  // second input digest
+  constexpr sycl::uchar digest_1[64] = {
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15
+  };
+
+  // >>> c = a + b
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_512(bytes(c)).digest())
+  //
+  // final output digest after merging two input digests
+  constexpr sycl::uchar digest_2[64] = {
+    73,  228, 11,  92,  59,  196, 139, 212, 163, 66,  229, 66,  106,
+    155, 168, 55,  241, 215, 241, 253, 75,  61,  91,  215, 172, 186,
+    250, 212, 10,  12,  61,  253, 80,  236, 57,  238, 27,  53,  53,
+    20,  81,  55,  63,  196, 104, 93,  94,  74,  19,  36,  181, 15,
+    41,  21,  198, 35,  60,  3,   65,  232, 15,  78,  220, 61
+  };
+
+  sycl::default_selector s{};
+  sycl::device d{ s };
+  sycl::context c{ d };
+  sycl::queue q{ c, d };
+
+  // so that input digests can be transferred from host to device ( by runtime )
+  sycl::uchar* in = static_cast<sycl::uchar*>(
+    sycl::malloc_shared(sizeof(digest_0) + sizeof(digest_1), q));
+
+  // so that output digest can be transferred from device to host ( by runtime )
+  sycl::uchar* out =
+    static_cast<sycl::uchar*>(sycl::malloc_shared(sizeof(digest_2), q));
+
+  // copy both input digests to device memory
+  q.memcpy(in + 0, digest_0, sizeof(digest_0)).wait();
+  q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
+
+  // compute 2-to-1 hash
+  q.single_task<class kernelExampleSHA3_512>(
+    [=]() { sha3_512::hash(in, out); });
+  q.wait();
+
+  // finally assert !
+  for (size_t i = 0; i < sizeof(digest_2); i++) {
+    assert(*(out + i) == digest_2[i]);
+  }
+
+  // deallocate resources !
+  sycl::free(in, q);
+  sycl::free(out, q);
+
+  return EXIT_SUCCESS;
+}

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -51,6 +51,9 @@ benchmark_merklize(sycl::queue& q,
 #elif defined SHA3_384
   const size_t i_size = leaf_cnt * sha3_384::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * sha3_384::OUT_LEN_BYTES; // in bytes
+#elif defined SHA3_512
+  const size_t i_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
+  const size_t o_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
 #endif
 
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256
@@ -66,7 +69,8 @@ benchmark_merklize(sycl::queue& q,
   sycl::ulong* o_h = static_cast<sycl::ulong*>(sycl::malloc_host(o_size, q));
   sycl::ulong* i_d = static_cast<sycl::ulong*>(sycl::malloc_device(i_size, q));
   sycl::ulong* o_d = static_cast<sycl::ulong*>(sycl::malloc_device(o_size, q));
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
   // allocate resources
   sycl::uchar* i_h = static_cast<sycl::uchar*>(sycl::malloc_host(i_size, q));
   sycl::uchar* o_h = static_cast<sycl::uchar*>(sycl::malloc_host(o_size, q));
@@ -129,6 +133,8 @@ benchmark_merklize(sycl::queue& q,
                      (sha3_224::OUT_LEN_BYTES)
 #elif defined SHA3_384
                      (sha3_384::OUT_LEN_BYTES)
+#elif defined SHA3_512
+                     (sha3_512::OUT_LEN_BYTES)
 #endif
 
          ;

--- a/include/merklize.hpp
+++ b/include/merklize.hpp
@@ -3,7 +3,7 @@
 #if !(defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                  \
       defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
       defined SHA2_512_256 || defined SHA3_256 || defined SHA3_224 ||          \
-      defined SHA3_384)
+      defined SHA3_384 || defined SHA3_512)
 #define SHA2_256
 #endif
 
@@ -37,6 +37,9 @@
 #elif defined SHA3_384
 #include "sha3_384.hpp"
 #pragma message "Choosing to compile Merklization with SHA3-384 !"
+#elif defined SHA3_512
+#include "sha3_512.hpp"
+#pragma message "Choosing to compile Merklization with SHA3-512 !"
 #endif
 
 // Binary merklization --- collects motivation from
@@ -52,7 +55,8 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          const sycl::ulong* __restrict leaf_nodes,
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
          const sycl::uchar* __restrict leaf_nodes,
 #endif
 
@@ -64,7 +68,8 @@ merklize(sycl::queue& q,
 #elif defined SHA2_384 || defined SHA2_512 || defined SHA2_512_224 ||          \
   defined SHA2_512_256
          sycl::ulong* const __restrict intermediates,
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
          sycl::uchar* const __restrict intermediates,
 #endif
 
@@ -108,12 +113,15 @@ merklize(sycl::queue& q,
 #elif defined SHA3_384
   assert(i_size == leaf_cnt * sha3_384::OUT_LEN_BYTES);
   assert(o_size == (itmd_cnt + 1) * sha3_384::OUT_LEN_BYTES);
+#elif defined SHA3_512
+  assert(i_size == leaf_cnt * sha3_512::OUT_LEN_BYTES);
+  assert(o_size == (itmd_cnt + 1) * sha3_512::OUT_LEN_BYTES);
 #endif
 
   // both input and output allocation has same size
 #if defined SHA1 || defined SHA2_224 || defined SHA2_256 ||                    \
   defined SHA2_384 || defined SHA2_512 || defined SHA2_512_256 ||              \
-  defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+  defined SHA3_256 || defined SHA3_224 || defined SHA3_384 || defined SHA3_512
 
   assert(i_size == o_size);
 
@@ -151,7 +159,8 @@ merklize(sycl::queue& q,
   //
   // note that `o_size` is in terms of bytes
   const size_t elm_cnt = o_size >> 3;
-#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384
+#elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
+  defined SHA3_512
   // # -of 8 -bit unsigned integers ( read a byte ), which can be contiguously
   // placed on output memory allocation
   //
@@ -215,6 +224,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_384
         const size_t in_idx = idx * sha3_384::IN_LEN_BYTES;
         const size_t out_idx = idx * sha3_384::OUT_LEN_BYTES;
+#elif defined SHA3_512
+        const size_t in_idx = idx * sha3_512::IN_LEN_BYTES;
+        const size_t out_idx = idx * sha3_512::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -253,6 +265,11 @@ merklize(sycl::queue& q,
         sycl::uchar* out = intermediates + o_offset + out_idx;
 
         sha3_384::hash(in, out);
+#elif defined SHA3_512
+        const sycl::uchar* in = leaf_nodes + i_offset + in_idx;
+        sycl::uchar* out = intermediates + o_offset + out_idx;
+
+        sha3_512::hash(in, out);
 #endif
       });
   });
@@ -378,6 +395,9 @@ merklize(sycl::queue& q,
 #elif defined SHA3_384
           const size_t in_idx = idx * sha3_384::IN_LEN_BYTES;
           const size_t out_idx = idx * sha3_384::OUT_LEN_BYTES;
+#elif defined SHA3_512
+          const size_t in_idx = idx * sha3_512::IN_LEN_BYTES;
+          const size_t out_idx = idx * sha3_512::OUT_LEN_BYTES;
 #endif
 
 #if defined SHA1
@@ -421,6 +441,11 @@ merklize(sycl::queue& q,
           sycl::uchar* out = intermediates + o_offset_ + out_idx;
 
           sha3_384::hash(in, out);
+#elif defined SHA3_512
+          const sycl::uchar* in = intermediates + i_offset_ + in_idx;
+          sycl::uchar* out = intermediates + o_offset_ + out_idx;
+
+          sha3_512::hash(in, out);
 #endif
         });
     });

--- a/include/sha3_512.hpp
+++ b/include/sha3_512.hpp
@@ -1,0 +1,163 @@
+#pragma once
+#include "sha3.hpp"
+
+namespace sha3_512 {
+
+// SHA3-512 specific input/ output width constants, taken from
+// table 4's in section A.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+constexpr size_t IN_LEN_BITS = 1024;
+constexpr size_t IN_LEN_BYTES = IN_LEN_BITS >> 3;
+
+constexpr size_t OUT_LEN_BITS = IN_LEN_BITS >> 1;
+constexpr size_t OUT_LEN_BYTES = IN_LEN_BYTES >> 1;
+
+constexpr size_t RATE_LEN_BITS = 576;
+constexpr size_t RATE_LEN_BYTES = RATE_LEN_BITS >> 3;
+
+// First absorb starting 576 -bits ( = 72 -bytes, note this is RATE for SHA3-512
+// ) of input byte array ( = 128 bytes ) preparing 5 x 5 x 64 keccak state array
+// as twenty five 64 -bit unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+//
+// Note total input is 1024 -bits wide
+void
+process_first_576_bits(const sycl::uchar* __restrict in,
+                       sycl::ulong* const __restrict state)
+{
+#pragma unroll 3
+  for (size_t i = 0; i < (RATE_LEN_BYTES >> 3); i++) {
+    state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+               static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+               static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+               static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+               static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+               static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+               static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+               static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+  }
+
+  // finally 1024 ( = capacity ) zero bits
+#pragma unroll 8
+  for (size_t i = 9; i < 25; i++) {
+    state[i] = 0ull;
+  }
+}
+
+// Then absorb remaining 448 -bits ( = 56 -bytes ) of input byte array ( = 128
+// -bytes ) preparing 5 x 6 x 64 keccak state array as twenty five 64 -bit
+// unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+//
+// Note total input is 1024 -bits wide
+void
+process_remaining_448_bits(const sycl::uchar* __restrict in,
+                           sycl::ulong* const __restrict state)
+{
+#pragma unroll 7
+  for (size_t i = 0; i < ((IN_LEN_BITS - RATE_LEN_BITS) >> 6); i++) {
+    state[i] = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+               static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+               static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+               static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+               static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+               static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+               static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+               static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+  }
+
+  // following two write ops actually pushing
+  // 0b10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000110
+  // bit pattern ( read in opposite order i.e. right to left ascending )
+  // at end of 448 -bit input message bits
+  //
+  // = 0b0000000000000000000000000000000000000000000000000000000000000110
+  state[7] = 0b110ull;
+  // = 0b1000000000000000000000000000000000000000000000000000000000000000
+  // = 1 << 63
+  state[8] = 9223372036854775808ull;
+
+  // finally 1024 ( = capacity ) zero bits
+#pragma unroll 8
+  for (size_t i = 9; i < 25; i++) {
+    state[i] = 0ull;
+  }
+}
+
+// Because RATE is small enough ( = 576 -bits ) that I'm required to absorb
+// whole padded input bits in two phases, after performing keccak-p[b, n_r]
+// permutation on first 576 input -bits, before second permutation can be
+// applied for absorbing remaining 448 input -bits, I'm required to mix current
+// state array ( in size 5 x 5 x 64 ) with previous state array
+//
+// Note total input is 1024 -bits wide
+static inline void
+mix_prev_into_cur_state(const sycl::ulong* __restrict prev,
+                        sycl::ulong* const __restrict cur)
+{
+#pragma unroll 8
+  for (size_t i = 0; i < 24; i++) {
+    cur[i] ^= prev[i];
+  }
+
+  cur[24] ^= prev[24];
+}
+
+// From absorbed hash state array of dimension 5 x 5 x 64, produces 64 -bytes
+// digest using method defined in section 3.1.3 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
+// B.1 of above hyperlinked document
+void
+to_digest_bytes(const sycl::ulong* __restrict in,
+                sycl::uchar* const __restrict digest)
+{
+#pragma unroll 4
+  for (size_t i = 0; i < 8; i++) {
+    const sycl::ulong lane = in[i];
+
+    digest[(i << 3) + 0] = static_cast<sycl::uchar>((lane >> 0) & 0xffull);
+    digest[(i << 3) + 1] = static_cast<sycl::uchar>((lane >> 8) & 0xffull);
+    digest[(i << 3) + 2] = static_cast<sycl::uchar>((lane >> 16) & 0xffull);
+    digest[(i << 3) + 3] = static_cast<sycl::uchar>((lane >> 24) & 0xffull);
+    digest[(i << 3) + 4] = static_cast<sycl::uchar>((lane >> 32) & 0xffull);
+    digest[(i << 3) + 5] = static_cast<sycl::uchar>((lane >> 40) & 0xffull);
+    digest[(i << 3) + 6] = static_cast<sycl::uchar>((lane >> 48) & 0xffull);
+    digest[(i << 3) + 7] = static_cast<sycl::uchar>((lane >> 56) & 0xffull);
+  }
+}
+
+// SHA3-512 2-to-1 hasher, where input is 128 contiguous bytes which is hashed
+// to produce 64 -bytes output
+//
+// This function itself doesn't do much instead of calling other functions
+// which actually
+// - prepares state bit array from first 576 input bits
+// - permutes input using `keccak-p[b, n_r]`
+// - then prepares another state bit array from remaining 448 input bits
+// - mixes ( read XORs ) previous state bit array into current state bit array
+// - permutes current input bit array using `keccak-p[b, n_r]`
+// - truncates first 512 -bits from final state bit array
+//
+// See section 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+void
+hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
+{
+  sycl::ulong state_0[25];
+  sycl::ulong state_1[25];
+
+  process_first_576_bits(in, state_0);
+  keccak_p(state_0);
+
+  process_remaining_448_bits(in + 72, state_1);
+  mix_prev_into_cur_state(state_0, state_1);
+  keccak_p(state_1);
+
+  to_digest_bytes(state_1, digest);
+}
+
+}

--- a/include/test_sha3_512.hpp
+++ b/include/test_sha3_512.hpp
@@ -1,0 +1,44 @@
+#pragma once
+#include "sha3_512.hpp"
+#include <cassert>
+
+void
+test_sha3_512(sycl::queue& q)
+{
+  // obtained by executing following snippet in python3 shell
+  //
+  // >>> import hashlib
+  // >>> list(hashlib.sha3_512(bytes([i for i in range(128)])).digest())
+  //
+  // note, same input is prepared inside 👇 for loop
+  constexpr sycl::uchar expected[64] = {
+    152, 156, 25,  149, 218, 157, 45,  52,  31,  153, 60,  46,  44,
+    166, 149, 243, 71,  112, 117, 6,   27,  251, 210, 205, 240, 190,
+    117, 207, 123, 169, 159, 190, 51,  216, 210, 196, 220, 195, 31,
+    168, 153, 23,  120, 107, 136, 62,  108, 157, 91,  2,   237, 129,
+    183, 72,  58,  76,  179, 234, 152, 103, 21,  136, 247, 69
+  };
+
+  // acquire resources
+  sycl::uchar* in = static_cast<sycl::uchar*>(sycl::malloc_shared(128, q));
+  sycl::uchar* out = static_cast<sycl::uchar*>(sycl::malloc_shared(64, q));
+
+#pragma unroll 16
+  for (size_t i = 0; i < 128; i++) {
+    // preparing input for testing 2-to-1 SHA3-512 hash
+    *(in + i) = i;
+  }
+
+  // enqueue kernel execution in single work-item model
+  q.single_task<class kernelTestSHA3_512>([=]() { sha3_512::hash(in, out); });
+  q.wait();
+
+  // check result !
+  for (size_t i = 0; i < 64; i++) {
+    assert(*(out + i) == expected[i]);
+  }
+
+  // ensure resources are deallocated
+  sycl::free(in, q);
+  sycl::free(out, q);
+}

--- a/results/sha3-512/intel_cpu.md
+++ b/results/sha3-512/intel_cpu.md
@@ -1,0 +1,134 @@
+### Binary Merklization using SHA3-512 on Intel CPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_512 make aot_cpu
+```
+
+### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          4
+On-line CPU(s) list:             0-3
+NUMA node0 CPU(s):               0-3
+```
+
+```bash
+running on Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                      1.422096 s                     6.655711 ms                     6.632538 ms
+        2 ^ 21                      2.826801 s                    13.003300 ms                    13.222868 ms
+        2 ^ 22                      5.655653 s                    27.421870 ms                    27.016023 ms
+        2 ^ 23                     11.310605 s                    53.933905 ms                    54.153294 ms
+        2 ^ 24                     23.166480 s                   107.621708 ms                   108.141864 ms
+        2 ^ 25                     46.915646 s                   215.222096 ms                   223.990513 ms
+```
+
+### On `Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          128
+On-line CPU(s) list:             0-127
+NUMA node0 CPU(s):               0-31,64-95
+NUMA node1 CPU(s):               32-63,96-127
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    18.212837 ms                     3.521151 ms                     1.154891 ms
+        2 ^ 21                    31.598131 ms                     8.554403 ms                     4.468314 ms
+        2 ^ 22                    57.098150 ms                    13.102806 ms                     4.367535 ms
+        2 ^ 23                   112.831001 ms                    17.162144 ms                     8.644232 ms
+        2 ^ 24                   222.342946 ms                    25.501501 ms                    17.274517 ms
+        2 ^ 25                   442.875605 ms                    51.969265 ms                    33.731850 ms
+```
+
+### On `Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-5,12-17
+NUMA node1 CPU(s):               6-11,18-23
+```
+
+```bash
+running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    83.168826 ms                     3.148146 ms                     1.616418 ms
+        2 ^ 21                   118.585412 ms                     5.744802 ms                     3.080455 ms
+        2 ^ 22                   232.349992 ms                    10.116922 ms                     6.071552 ms
+        2 ^ 23                   463.172213 ms                    17.845495 ms                    12.323518 ms
+        2 ^ 24                   924.780638 ms                    35.928981 ms                    26.567100 ms
+        2 ^ 25                      1.853150 s                    92.435423 ms                    54.594908 ms
+```
+
+### On `Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          24
+On-line CPU(s) list:             0-23
+NUMA node0 CPU(s):               0-23
+```
+
+```bash
+running on Intel(R) Core(TM) i9-10920X CPU @ 3.50GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                    55.401972 ms                     2.028286 ms                     1.841675 ms
+        2 ^ 21                   104.913798 ms                     4.298537 ms                     3.958525 ms
+        2 ^ 22                   204.813210 ms                     8.176016 ms                     7.942972 ms
+        2 ^ 23                   407.979027 ms                    16.235003 ms                    15.930501 ms
+        2 ^ 24                   815.037735 ms                    31.475015 ms                    31.085153 ms
+        2 ^ 25                      1.644981 s                    62.561881 ms                    62.212671 ms
+```
+
+### On `Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz`
+
+```bash
+$ lscpu | grep -i cpu\(s\)
+
+CPU(s):                          12
+On-line CPU(s) list:             0-11
+NUMA node0 CPU(s):               0-11
+```
+
+```bash
+running on Intel(R) Xeon(R) E-2176G CPU @ 3.70GHz
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   203.357929 ms                     1.772444 ms                     1.711588 ms
+        2 ^ 21                   405.166609 ms                     3.473879 ms                     3.392248 ms
+        2 ^ 22                   809.711764 ms                     6.936534 ms                     6.848052 ms
+        2 ^ 23                      1.735337 s                    13.794764 ms                    13.937174 ms
+        2 ^ 24                      3.465506 s                    27.510037 ms                    27.550688 ms
+        2 ^ 25                      6.932260 s                    55.162014 ms                    54.967118 ms
+```

--- a/results/sha3-512/intel_gpu.md
+++ b/results/sha3-512/intel_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-512 on Intel GPU(s)
+
+Compiling with
+
+```bash
+SHA=sha3_512 make aot_gpu
+```
+
+### On `Intel(R) UHD Graphics P630 [0x3e96]`
+
+```bash
+running on Intel(R) UHD Graphics P630 [0x3e96]
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                   289.603807 ms                     1.504084 ms                     1.416810 ms
+        2 ^ 21                   576.084968 ms                     2.882175 ms                     2.812580 ms
+        2 ^ 22                      1.148452 s                     5.658525 ms                     5.527675 ms
+        2 ^ 23                      2.294983 s                    11.162608 ms                    11.004991 ms
+        2 ^ 24                      4.582099 s                    22.103979 ms                    21.868923 ms
+        2 ^ 25                      9.163329 s                    43.960825 ms                    44.113151 ms
+```

--- a/results/sha3-512/nvidia_gpu.md
+++ b/results/sha3-512/nvidia_gpu.md
@@ -1,0 +1,24 @@
+### Binary Merklization using SHA3-512 on Nvidia GPU(s)
+
+Compile with
+
+```bash
+SHA=sha3_512 make cuda
+```
+
+### On `Tesla V100-SXM2-16GB`
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+
+Benchmarking Binary Merklization using SHA3-512
+
+      leaf count                  execution time                host-to-device tx time          device-to-host tx time
+        2 ^ 20                     1.764427 ms                     2.308462 ms                     2.009170 ms
+        2 ^ 21                     3.197203 ms                     4.596451 ms                     4.014771 ms
+        2 ^ 22                     5.991760 ms                     9.152618 ms                     8.026062 ms
+        2 ^ 23                     9.980712 ms                    18.291870 ms                    16.050659 ms
+        2 ^ 24                    19.426758 ms                    36.573853 ms                    32.111572 ms
+        2 ^ 25                    38.345214 ms                    73.152832 ms                    64.349121 ms
+```

--- a/run.sh
+++ b/run.sh
@@ -4,13 +4,19 @@
 
 make clean
 
+# SHA1 related tests
 SHA=sha1         make; make clean
+
+# SHA2 related tests
 SHA=sha2_224     make; make clean
 SHA=sha2_256     make; make clean
 SHA=sha2_384     make; make clean
 SHA=sha2_512     make; make clean
 SHA=sha2_512_224 make; make clean
 SHA=sha2_512_256 make; make clean
-SHA=sha3_256 make; make clean
-SHA=sha3_224 make; make clean
-SHA=sha3_384 make; make clean
+
+# SHA3 related tests
+SHA=sha3_256     make; make clean
+SHA=sha3_224     make; make clean
+SHA=sha3_384     make; make clean
+SHA=sha3_512     make; make clean

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,6 +21,8 @@
 #include "test_sha3_224.hpp"
 #elif defined SHA3_384
 #include "test_sha3_384.hpp"
+#elif defined SHA3_512
+#include "test_sha3_512.hpp"
 #endif
 
 int
@@ -86,6 +88,11 @@ main(int argc, char** argv)
   test_sha3_384(q);
   std::cout << "passed SHA3-384 test !" << std::endl;
 
+#elif defined SHA3_512
+
+  test_sha3_512(q);
+  std::cout << "passed SHA3-512 test !" << std::endl;
+
 #endif
 
   test_merklize(q);
@@ -118,6 +125,9 @@ main(int argc, char** argv)
             << std::endl;
 #elif defined SHA3_384
   std::cout << "passed binary merklization ( using SHA3-384 ) test !"
+            << std::endl;
+#elif defined SHA3_512
+  std::cout << "passed binary merklization ( using SHA3-512 ) test !"
             << std::endl;
 #endif
 


### PR DESCRIPTION
- Implement SHA3-512 -bit variant
- Write test cases for asserting that SHA3-512 works as expected
- Extend binary Merklization to use SHA3-512 as 2-to-1 hash function choice
- Extend benchmarking of binary merklization, along with that add relevant benchmark results
