### PR TITLE
Keccak256 using 32 -bit words ( bit interleaving technique )

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ If you happen to be interested in Binary Merklization using Rescue Prime Hash/ B
 
 > During Keccak256 implementation, I took some inspiration from [here](https://keccak.team/files/Keccak-implementation-3.2.pdf); though note that, keccak256 & sha3-256 are very much similar, except input message padding rule; see https://github.com/itzmeanjan/merklize-sha/pull/10 PR description.
 
+> I'm also keeping an alternative implementation of keccak256 2-to-1 hash, where each 64 -bit lane of keccak-p[1600, 24] state array is represented in terms of two 32 -bit unsigned integers ( in bit interleaved form ) and applying rounds involve only using 32 -bit bitwise operations. This implementation takes motivation from section 2.1 of [this](https://keccak.team/files/Keccak-implementation-3.2.pdf) document. *If interested see keccak256 2-to-1 hash implementation using 32 -bit word size, [here](https://github.com/itzmeanjan/merklize-sha/blob/12f61fa52b5eb2d674a4dafd124585a9a76dae52/include/keccak_256.hpp#L232-L257)*. **This same implementation guided me while writing keccak256 2-to-1 hash function in Polygon Miden Assembly**, see [PR](https://github.com/maticnetwork/miden/pull/154).
+
 > Using SHA1 for binary merklization may not be a good choice these days, see [here](https://csrc.nist.gov/Projects/Hash-Functions/NIST-Policy-on-Hash-Functions). But still I'm keeping SHA1 implementation, just as a reference.
 
 ## Prerequisites
@@ -90,7 +92,7 @@ If you happen to be interested in 2-to-1 hash implementation of
 - [SHA3-256](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_256.cpp)
 - [SHA3-384](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_384.cpp)
 - [SHA3-512](https://github.com/itzmeanjan/merklize-sha/blob/8f9b168/example/sha3_512.cpp)
-- [KECCAK-256](https://github.com/itzmeanjan/merklize-sha/blob/75dfd47/example/keccak_256.cpp)
+- [KECCAK-256](https://github.com/itzmeanjan/merklize-sha/blob/fb41136/example/keccak_256.cpp)
 
 where two digests of respective hash functions are input, in byte concatenated form, to `hash( ... )` function, consider taking a look at above hyperlinked examples.
 

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -73,10 +73,16 @@ main(int argc, char** argv)
 #elif defined SHA3_512
   std::cout << "\nBenchmarking Binary Merklization using SHA3-512" << std::endl
             << std::endl;
-#elif defined KECCAK_256
-  std::cout << "\nBenchmarking Binary Merklization using KECCAK-256"
-            << std::endl
-            << std::endl;
+#elif defined KECCAK_256_U64
+  std::cout
+    << "\nBenchmarking Binary Merklization using KECCAK-256 ( 64 -bit word )"
+    << std::endl
+    << std::endl;
+#elif defined KECCAK_256_U32
+  std::cout
+    << "\nBenchmarking Binary Merklization using KECCAK-256 ( 32 -bit word )"
+    << std::endl
+    << std::endl;
 #endif
 
   std::cout << std::setw(16) << std::right << "leaf count"

--- a/example/keccak_256.cpp
+++ b/example/keccak_256.cpp
@@ -51,8 +51,13 @@ main(int argc, char** argv)
   q.memcpy(in + sizeof(digest_0), digest_1, sizeof(digest_1)).wait();
 
   // compute 2-to-1 hash
-  q.single_task<class kernelExampleKECCAK_256>(
-    [=]() { keccak_256::hash(in, out); });
+  q.single_task<class kernelExampleKECCAK_256>([=]() {
+    // if you want, you can replace `keccak_256::hash` with
+    // `keccak_256::hash_u32`, which represents each lane of state array using
+    // two 32 -bit unsigned integers ( bit interleaved form ) and uses only 32
+    // -bit bitwise operations when computing keccak256 2-to-1 hash
+    keccak_256::hash(in, out);
+  });
   q.wait();
 
   // finally assert !

--- a/include/bench_merklize.hpp
+++ b/include/bench_merklize.hpp
@@ -54,7 +54,7 @@ benchmark_merklize(sycl::queue& q,
 #elif defined SHA3_512
   const size_t i_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
   const size_t i_size = leaf_cnt * keccak_256::OUT_LEN_BYTES; // in bytes
   const size_t o_size = leaf_cnt * keccak_256::OUT_LEN_BYTES; // in bytes
 #endif
@@ -73,7 +73,7 @@ benchmark_merklize(sycl::queue& q,
   sycl::ulong* i_d = static_cast<sycl::ulong*>(sycl::malloc_device(i_size, q));
   sycl::ulong* o_d = static_cast<sycl::ulong*>(sycl::malloc_device(o_size, q));
 #elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
   // allocate resources
   sycl::uchar* i_h = static_cast<sycl::uchar*>(sycl::malloc_host(i_size, q));
   sycl::uchar* o_h = static_cast<sycl::uchar*>(sycl::malloc_host(o_size, q));
@@ -138,7 +138,7 @@ benchmark_merklize(sycl::queue& q,
                      (sha3_384::OUT_LEN_BYTES)
 #elif defined SHA3_512
                      (sha3_512::OUT_LEN_BYTES)
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
                      (keccak_256::OUT_LEN_BYTES)
 #endif
 

--- a/include/keccak_256.hpp
+++ b/include/keccak_256.hpp
@@ -70,6 +70,88 @@ to_state_array(const sycl::uchar* __restrict in,
   }
 }
 
+// From input byte array ( = 64 bytes ) preparing 5 x 5 x 64 keccak state array
+// as twenty five 64 -bit unsigned integers
+//
+// Combined techniques adapted from section 3.1.2 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202; algorithm 10
+// defined in section B.1 of above linked document
+//
+// Note, in SHA3 specification padding rule is different than what it's for
+// keccak-256 i.e. to be very spcific, compare
+// https://github.com/itzmeanjan/merklize-sha/blob/e421134ea4c9b1a832458bc870c3e79dc2849ecc/include/sha3_256.hpp#L43
+// ( this is sha3-256 implementation ) and write to 9-th state lane ( at index 8
+// of state array ) in following function body
+//
+// I suggest you read https://keccak.team/files/Keccak-implementation-3.2.pdf 's
+// section 1.1 where padding rule is defined under `Keccak[r, c](M)` definition
+//
+// Standard representation of keccak state array is converted to bit interleaved
+// representation so that each lane of state array is represented in terms two
+// limbs, each of 32 -bit wide; this will help us in using only 32 -bit bitwise
+// operations while computing keccak-p[1600, 24] permutation
+void
+to_state_array(const sycl::uchar* __restrict in,
+               sycl::uint* const __restrict state)
+{
+#pragma unroll 8
+  for (size_t i = 0; i < 8; i++) {
+    const uint64_t word = static_cast<sycl::ulong>(in[(i << 3) + 7]) << 56 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 6]) << 48 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 5]) << 40 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 4]) << 32 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 3]) << 24 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 2]) << 16 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 1]) << 8 |
+                          static_cast<sycl::ulong>(in[(i << 3) + 0]) << 0;
+
+    uint32_t even, odd;
+    to_bit_interleaved(word, &even, &odd);
+
+    state[(i << 1) + 0] = even;
+    state[(i << 1) + 1] = odd;
+  }
+
+  // see how 0b01 is padded to input message; following keccak-256
+  // implementation guide
+  // https://keccak.team/files/Keccak-implementation-3.2.pdf 's section 1.1
+  // where `Keccak[r, c](M)` is defined ( spcifically padding rule block in
+  // pseudocode, at very end of mentioned section )
+  //
+  // ! read right to left !
+  uint64_t word = 0b1ull;
+  uint32_t even, odd;
+  to_bit_interleaved(word, &even, &odd);
+
+  state[16] = even;
+  state[17] = odd;
+
+#pragma unroll 7
+  for (size_t i = 9; i < 16; i++) {
+    state[(i << 1) + 0] = 0u;
+    state[(i << 1) + 1] = 0u;
+  }
+
+  // this 1 is added to input message bits due to padding requirement
+  // defined in keccak-256 implementation guide
+  // https://keccak.team/files/Keccak-implementation-3.2.pdf 's section 1.1
+  // where `Keccak[r, c](M)` is defined ( spcifically padding rule block in
+  // pseudocode, at very end of mentioned section )
+  //
+  // ! read right to left, so it's actually 1 << 63 !
+  word = 9223372036854775808ull;
+  to_bit_interleaved(word, &even, &odd);
+
+  state[32] = even;
+  state[33] = odd;
+
+#pragma unroll 8
+  for (size_t i = 17; i < 25; i++) {
+    state[(i << 1) + 0] = 0u;
+    state[(i << 1) + 1] = 0u;
+  }
+}
+
 // From absorbed hash state array of dimension 5 x 5 x 64, produces 32 -bytes
 // digest using method defined in section 3.1.3 of
 // http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
@@ -95,6 +177,37 @@ to_digest_bytes(const sycl::ulong* __restrict in,
   }
 }
 
+// From absorbed hash state array of dimension 5 x 5 x 64, produces 32 -bytes
+// digest using method defined in section 3.1.3 of
+// http://dx.doi.org/10.6028/NIST.FIPS.202 and algorithm 11 defined in section
+// B.1 of above hyperlinked document
+//
+// Note, digest preparation method is same for both sha3-256 and keccak-256
+//
+// Bit interleaved representation of keccak state array is converted to standard
+// representation for generating 2-to-1 hash digest
+void
+to_digest_bytes(const uint32_t* __restrict in,
+                sycl::uchar* const __restrict digest)
+{
+#pragma unroll 4
+  for (size_t i = 0; i < 4; i++) {
+    const sycl::uint lane_even = in[(i << 1) + 0];
+    const sycl::uint lane_odd = in[(i << 1) + 1];
+
+    const uint64_t word = from_bit_interleaved(lane_even, lane_odd);
+
+    digest[(i << 3) + 0] = static_cast<sycl::uchar>((word >> 0) & 0xffull);
+    digest[(i << 3) + 1] = static_cast<sycl::uchar>((word >> 8) & 0xffull);
+    digest[(i << 3) + 2] = static_cast<sycl::uchar>((word >> 16) & 0xffull);
+    digest[(i << 3) + 3] = static_cast<sycl::uchar>((word >> 24) & 0xffull);
+    digest[(i << 3) + 4] = static_cast<sycl::uchar>((word >> 32) & 0xffull);
+    digest[(i << 3) + 5] = static_cast<sycl::uchar>((word >> 40) & 0xffull);
+    digest[(i << 3) + 6] = static_cast<sycl::uchar>((word >> 48) & 0xffull);
+    digest[(i << 3) + 7] = static_cast<sycl::uchar>((word >> 56) & 0xffull);
+  }
+}
+
 // Keccak-256 2-to-1 hasher, where input is 64 contiguous bytes which is hashed
 // to produce 32 -bytes output
 //
@@ -110,6 +223,33 @@ void
 hash(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
 {
   sycl::ulong state[25];
+
+  to_state_array(in, state);
+  keccak_p(state);
+  to_digest_bytes(state, digest);
+}
+
+// Keccak-256 2-to-1 hasher, where input is 64 contiguous bytes which is hashed
+// to produce 32 -bytes output
+//
+// This function itself doesn't do much instead of calling other functions
+// which actually
+// - prepares bit interleaved state bit array from input byte array ( using two
+// 32 -bit words for each lane )
+// - permutes input using `keccak-p[b, n_r]`
+// - truncates first 256 -bits from state bit array and converts to standard
+// representation from bit interleaved form
+//
+// See section 6.1 of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// For more info on bit interleaved representation, see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+void
+hash_u32(const sycl::uchar* __restrict in, sycl::uchar* const __restrict digest)
+{
+  // holds bit interleaved representation of state array i.e. each lane will be
+  // splitted into two limbs ( each of 32 -bit wide )
+  uint32_t state[50];
 
   to_state_array(in, state);
   keccak_p(state);

--- a/include/sha3.hpp
+++ b/include/sha3.hpp
@@ -56,6 +56,51 @@ static inline void
 //
 // Input is 5 x 5 x 64 state array and output is in-place modified state array
 //
+// See specification of `θ` step mapping function in section 3.2.1
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, word size is 32 -bit, so expects keccak-p[1600, 24] state array/ round
+// constants in bit interleaved form; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+static inline void
+θ(uint32_t* const state)
+{
+  uint32_t c[10];
+  uint32_t d[10];
+
+  // see step 1 of algorithm 1
+#pragma unroll 5
+  for (size_t x = 0; x < 10; x++) {
+    const uint32_t t0 = state[x] ^ state[x + 10];
+    const uint32_t t1 = state[x + 20] ^ state[x + 30];
+    const uint32_t t2 = t0 ^ t1 ^ state[x + 40];
+
+    c[x] = t2;
+  }
+
+  // see step 2 of algorithm 1
+  for (size_t x = 0; x < 5; x++) {
+    const size_t p_idx = ((x + 4) % 5) << 1;
+    const size_t n_idx = ((x + 1) % 5) << 1;
+    const size_t c_idx = x << 1;
+
+    // read section 2.1 of
+    // https://keccak.team/files/Keccak-implementation-3.2.pdf
+    d[c_idx + 0] = c[p_idx + 0] ^ rotl(c[n_idx + 1], 1);
+    d[c_idx + 1] = c[p_idx + 1] ^ c[n_idx + 0];
+  }
+
+  // see step 3 of algorithm 1
+#pragma unroll 5
+  for (size_t x = 0; x < 50; x++) {
+    state[x] ^= d[x % 10];
+  }
+}
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is in-place modified state array
+//
 // See specification of `ρ` step mapping function in section 3.2.2
 // of http://dx.doi.org/10.6028/NIST.FIPS.202
 static inline void
@@ -64,6 +109,40 @@ static inline void
 #pragma unroll 8
   for (size_t i = 1; i < 25; i++) {
     state[i] = rotl(state[i], ROT[i - 1]);
+  }
+}
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is in-place modified state array
+//
+// See specification of `ρ` step mapping function in section 3.2.2
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, word size is 32 -bit, so expects keccak-p[1600, 24] state array/ round
+// constants in bit interleaved form; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+static inline void
+ρ(uint32_t* const state)
+{
+#pragma unroll 8
+  for (size_t i = 1; i < 25; i++) {
+    const size_t c_idx = i << 1;
+    const size_t offset = ROT[i - 1];
+
+    // read section 2.1 of
+    // https://keccak.team/files/Keccak-implementation-3.2.pdf
+    //
+    if ((offset & 0b1) == 0) { // even
+      state[c_idx + 0] = rotl(state[c_idx + 0], offset >> 1);
+      state[c_idx + 1] = rotl(state[c_idx + 1], offset >> 1);
+    } else { // odd
+      const uint32_t even = rotl(state[c_idx + 1], (offset >> 1) + 1);
+      const uint32_t odd = rotl(state[c_idx + 0], offset >> 1);
+
+      state[c_idx + 0] = even;
+      state[c_idx + 1] = odd;
+    }
   }
 }
 
@@ -83,6 +162,46 @@ static inline void
 #pragma unroll 5
     for (size_t x = 0; x < 5; x++) {
       state_out[y * 5 + x] = state_in[5 * x + (x + 3 * y) % 5];
+    }
+  }
+}
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array and output is modified state array
+//
+// See specification of `π` step mapping function in section 3.2.3
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, word size is 32 -bit, so expects keccak-p[1600, 24] state array/ round
+// constants in bit interleaved form; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+static inline void
+π(uint32_t* const __restrict state)
+{
+  uint32_t tmp[50];
+
+  // step 1 of algorithm 3
+#pragma unroll 5
+  for (size_t y = 0; y < 5; y++) {
+#pragma unroll 5
+    for (size_t x = 0; x < 5; x++) {
+      const size_t idx = (y * 5 + x) << 1;
+
+      tmp[idx + 0] = state[idx + 0];
+      tmp[idx + 1] = state[idx + 1];
+    }
+  }
+
+#pragma unroll 5
+  for (size_t y = 0; y < 5; y++) {
+#pragma unroll 5
+    for (size_t x = 0; x < 5; x++) {
+      const size_t to_idx = (y * 5 + x) << 1;
+      const size_t frm_idx = (5 * x + (x + 3 * y) % 5) << 1;
+
+      state[to_idx + 0] = tmp[frm_idx + 0];
+      state[to_idx + 1] = tmp[frm_idx + 1];
     }
   }
 }
@@ -113,6 +232,46 @@ static inline void
 
 // keccak-p[b, n_r] step mapping
 //
+// Input is 5 x 5 x 64 state array and output is modified state array
+//
+// See specification of `χ` step mapping function in section 3.2.4
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, word size is 32 -bit, so expects keccak-p[1600, 24] state array/ round
+// constants in bit interleaved form; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+static inline void
+χ(uint32_t* const __restrict state)
+{
+  // step 1 of algorithm 4
+  uint32_t c[10];
+
+#pragma unroll 5
+  for (size_t y = 0; y < 5; y++) {
+#pragma unroll 5
+    for (size_t x = 0; x < 5; x++) {
+      const size_t x_0 = (y * 5 + (x + 1) % 5) << 1;
+      const size_t x_1 = (y * 5 + (x + 2) % 5) << 1;
+
+      const uint32_t rhs_0 = ~state[x_0 + 0] & state[x_1 + 0];
+      const uint32_t rhs_1 = ~state[x_0 + 1] & state[x_1 + 1];
+
+      c[(x << 1) + 0] = rhs_0;
+      c[(x << 1) + 1] = rhs_1;
+    }
+
+#pragma unroll 5
+    for (size_t x = 0; x < 5; x++) {
+      const size_t idx = (y * 5 + x) << 1;
+
+      state[idx + 0] ^= c[(x << 1) + 0];
+      state[idx + 1] ^= c[(x << 1) + 1];
+    }
+  }
+}
+
+// keccak-p[b, n_r] step mapping
+//
 // Input is 5 x 5 x 64 state array, along with round index ∈ [0, 24)
 // Output is modified state array
 //
@@ -124,6 +283,26 @@ static inline void
 {
   // step 4 of algorithm 6
   state[0] ^= rc;
+}
+
+// keccak-p[b, n_r] step mapping
+//
+// Input is 5 x 5 x 64 state array, along with round index ∈ [0, 24)
+// Output is modified state array
+//
+// See specification of `ι` step mapping function in section 3.2.5
+// of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, word size is 32 -bit, so expects keccak-p[1600, 24] state array/ round
+// constants in bit interleaved form; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+template<const uint32_t rc_even, const uint32_t rc_odd>
+static inline void
+ι(uint32_t* const state)
+{
+  // step 4 of algorithm 6
+  state[0] ^= rc_even;
+  state[1] ^= rc_odd;
 }
 
 // keccak-p[b, n_r] round function, which applies all five
@@ -141,6 +320,25 @@ rnd(sycl::ulong* const state)
   π(state, tmp);
   χ(tmp, state);
   ι<rc>(state);
+}
+
+// keccak-p[b, n_r] round function, which applies all five
+// step mapping functions in order, updating state array
+//
+// See section 3.3 of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, word size is 32 -bit, so expects keccak-p[1600, 24] state array/ round
+// constants in bit interleaved form; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf
+template<const uint32_t rc_even, const uint32_t rc_odd>
+static inline void
+rnd(uint32_t* const state)
+{
+  θ(state);
+  ρ(state);
+  π(state);
+  χ(state);
+  ι<rc_even, rc_odd>(state);
 }
 
 // keccak-p[b, n_r] permutation, applying n_r ( = 24 ) rounds
@@ -176,4 +374,54 @@ keccak_p(sycl::ulong* const state)
   rnd<9223372036854808704ull>(state);
   rnd<2147483649ull>(state);
   rnd<9223372039002292232ull>(state);
+}
+
+// keccak-p[b, n_r] permutation, applying n_r ( = 24 ) rounds
+// on state bit array of dimension 5 x 5 x 64, using algorithm 7
+// defined in section 3.3 of http://dx.doi.org/10.6028/NIST.FIPS.202
+//
+// Note, this function works with 32 -bit word size, while function written just
+// above it works with 64 -bit word size.
+//
+// Bit interleaving is the technique used for working with 32 -bit unsigned
+// integers; see section 2.1 of
+// https://keccak.team/files/Keccak-implementation-3.2.pdf for more info
+//
+// You may also want to see
+// https://github.com/XKCP/XKCP/blob/f07a7f6/lib/low/KeccakP-1600/ref-32bits/KeccakP-1600-reference32BI.c#L336-L521
+// as an alternative implementation with 32 -bit word size, which worked as an
+// inspiration to me
+static inline void
+keccak_p(uint32_t* const state)
+{
+  // step 2 of algorithm 7
+  //
+  // all 24 keccak-p permutation rounds sequentially applied
+  //
+  // for bit interleaved round constants see
+  // https://github.com/XKCP/XKCP/blob/f07a7f6/lib/low/KeccakP-1600/ref-32bits/KeccakP-1600-reference32BI.c#L153-L179
+  rnd<1u, 0u>(state);
+  rnd<0u, 137u>(state);
+  rnd<0u, 2147483787u>(state);
+  rnd<0u, 2147516544u>(state);
+  rnd<1u, 139u>(state);
+  rnd<1u, 32768u>(state);
+  rnd<1u, 2147516552u>(state);
+  rnd<1u, 2147483778u>(state);
+  rnd<0u, 11u>(state);
+  rnd<0u, 10u>(state);
+  rnd<1u, 32898u>(state);
+  rnd<0u, 32771u>(state);
+  rnd<1u, 32907u>(state);
+  rnd<1u, 2147483659u>(state);
+  rnd<1u, 2147483786u>(state);
+  rnd<1u, 2147483777u>(state);
+  rnd<0u, 2147483777u>(state);
+  rnd<0u, 2147483656u>(state);
+  rnd<0u, 131u>(state);
+  rnd<0u, 2147516419u>(state);
+  rnd<1u, 2147516552u>(state);
+  rnd<0u, 2147483784u>(state);
+  rnd<1u, 32768u>(state);
+  rnd<0u, 2147516546u>(state);
 }

--- a/include/test_bit_interleaving.hpp
+++ b/include/test_bit_interleaving.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include "utils.hpp"
+#include <cassert>
+#include <random>
+
+constexpr bool
+gt_n(const size_t rounds, const size_t n)
+{
+  return rounds > n;
+}
+
+// Generate random 64 -bit unsigned integer, which is transformed to bit
+// interleaved form ( even & odd parts ) & again converted back to standard
+// representation by merging bit interleaved even, odd parts --- assert equality
+// of final standard representation and original u64 random number generated
+template<const size_t rounds>
+void
+test_bit_interleaving() requires(gt_n(rounds, 0))
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  // [0, (1 << 64) - 1]
+  std::uniform_int_distribution<uint64_t> dis(0, 18446744073709551615ull);
+
+#pragma unroll 16
+  for (size_t i = 0; i < rounds; i++) {
+    const uint64_t word = dis(gen);
+    uint32_t even, odd;
+
+    to_bit_interleaved(word, &even, &odd);
+    const uint64_t word_ = from_bit_interleaved(even, odd);
+
+    assert(word == word_);
+  }
+}

--- a/include/test_merklize.hpp
+++ b/include/test_merklize.hpp
@@ -44,7 +44,7 @@ test_merklize(sycl::queue& q)
 #elif defined SHA3_512
   constexpr size_t i_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
   constexpr size_t o_size = leaf_cnt * sha3_512::OUT_LEN_BYTES; // in bytes
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
   constexpr size_t i_size = leaf_cnt * keccak_256::OUT_LEN_BYTES; // in bytes
   constexpr size_t o_size = leaf_cnt * keccak_256::OUT_LEN_BYTES; // in bytes
 #endif
@@ -321,7 +321,7 @@ test_merklize(sycl::queue& q)
     177, 100, 141, 206, 4,   39,  65,  1,   168, 4,  149, 112, 77,
     212, 175, 50,  150, 42,  29,  174, 20,  201, 12, 120, 26
   };
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
   // $ python3 -m pip install --user pysha3
   // $ python3
   //
@@ -361,14 +361,14 @@ test_merklize(sycl::queue& q)
   sycl::ulong* out_0 = (sycl::ulong*)sycl::malloc_shared(o_size, q);
   sycl::uchar* out_1 = (sycl::uchar*)sycl::malloc_shared(o_size, q);
 #elif defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||              \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
   // acquire resources
   sycl::uchar* in = (sycl::uchar*)sycl::malloc_shared(i_size, q);
   sycl::uchar* out = (sycl::uchar*)sycl::malloc_shared(o_size, q);
 #endif
 
 #if defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||                \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
 
   // prepare input bytes
   q.memset(in, 0xff, i_size).wait();
@@ -419,7 +419,7 @@ test_merklize(sycl::queue& q)
 #endif
 
 #if defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||                \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
 
   // wait until completely merklized !
   merklize(q, in, i_size, leaf_cnt, out, o_size, leaf_cnt - 1, leaf_cnt >> 1);
@@ -478,7 +478,7 @@ test_merklize(sycl::queue& q)
                      sha3_384::OUT_LEN_BYTES
 #elif defined SHA3_512
                      sha3_512::OUT_LEN_BYTES
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
                      keccak_256::OUT_LEN_BYTES
 #endif
 
@@ -486,7 +486,7 @@ test_merklize(sycl::queue& q)
 
        i++) {
 #if defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||                \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
 
     assert(*(out + i) == 0);
 
@@ -545,7 +545,7 @@ test_merklize(sycl::queue& q)
   for (size_t i = sha3_512::OUT_LEN_BYTES, j = 0;
        i < (sha3_512::OUT_LEN_BYTES << 1) && j < sha3_512::OUT_LEN_BYTES;
        i++, j++)
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
   for (size_t i = keccak_256::OUT_LEN_BYTES, j = 0;
        i < (keccak_256::OUT_LEN_BYTES << 1) && j < keccak_256::OUT_LEN_BYTES;
        i++, j++)
@@ -553,7 +553,7 @@ test_merklize(sycl::queue& q)
 
   {
 #if defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||                \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
 
     assert(*(out + i) == expected[j]);
 
@@ -566,7 +566,7 @@ test_merklize(sycl::queue& q)
 
   // ensure resources are deallocated
 #if defined SHA3_256 || defined SHA3_224 || defined SHA3_384 ||                \
-  defined SHA3_512 || defined KECCAK_256
+  defined SHA3_512 || defined KECCAK_256_U64 || defined KECCAK_256_U32
 
   sycl::free(in, q);
   sycl::free(out, q);

--- a/results/keccak-256/intel_cpu.md
+++ b/results/keccak-256/intel_cpu.md
@@ -3,7 +3,9 @@
 Compiling with
 
 ```bash
-SHA=keccak_256 make aot_cpu
+SHA=keccak_256_u64 make aot_cpu
+
+# if interested, also do `SHA=keccak_256_u32 make aot_cpu`
 ```
 
 ### On `Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`

--- a/results/keccak-256/intel_gpu.md
+++ b/results/keccak-256/intel_gpu.md
@@ -3,7 +3,9 @@
 Compiling with
 
 ```bash
-SHA=keccak_256 make aot_gpu
+SHA=keccak_256_u64 make aot_gpu
+
+# if interested, also do `SHA=keccak_256_u32 make aot_gpu`
 ```
 
 ### On `Intel(R) UHD Graphics P630 [0x3e96]`

--- a/results/keccak-256/nvidia_gpu.md
+++ b/results/keccak-256/nvidia_gpu.md
@@ -3,7 +3,9 @@
 Compile with
 
 ```bash
-SHA=keccak_256 make cuda
+SHA=keccak_256_u64 make cuda
+
+# if interested, also do `SHA=keccak_256_u32 make cuda`
 ```
 
 ### On `Tesla V100-SXM2-16GB`

--- a/run.sh
+++ b/run.sh
@@ -20,4 +20,5 @@ SHA=sha3_256     make; make clean
 SHA=sha3_224     make; make clean
 SHA=sha3_384     make; make clean
 SHA=sha3_512     make; make clean
-SHA=keccak_256     make; make clean
+SHA=keccak_256_u64     make; make clean
+SHA=keccak_256_u32     make; make clean

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -24,7 +24,7 @@
 #include "test_sha3_384.hpp"
 #elif defined SHA3_512
 #include "test_sha3_512.hpp"
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
 #include "test_keccak_256.hpp"
 #endif
 
@@ -99,7 +99,7 @@ main(int argc, char** argv)
   test_sha3_512(q);
   std::cout << "passed SHA3-512 test !" << std::endl;
 
-#elif defined KECCAK_256
+#elif defined KECCAK_256_U64 || defined KECCAK_256_U32
 
   test_keccak_256(q);
   std::cout << "passed Keccak-256 test !" << std::endl;
@@ -140,9 +140,14 @@ main(int argc, char** argv)
 #elif defined SHA3_512
   std::cout << "passed binary merklization ( using SHA3-512 ) test !"
             << std::endl;
-#elif defined KECCAK_256
-  std::cout << "passed binary merklization ( using KECCAK-256 ) test !"
-            << std::endl;
+#elif defined KECCAK_256_U64
+  std::cout
+    << "passed binary merklization ( using KECCAK-256, 64 -bit word ) test !"
+    << std::endl;
+#elif defined KECCAK_256_U32
+  std::cout
+    << "passed binary merklization ( using KECCAK-256, 32 -bit word ) test !"
+    << std::endl;
 #endif
 
   return EXIT_SUCCESS;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,4 @@
+#include "test_bit_interleaving.hpp"
 #include "test_merklize.hpp"
 #include <iostream>
 
@@ -39,6 +40,9 @@ main(int argc, char** argv)
   std::cout << "running on " << d.get_info<sycl::info::device::name>()
             << std::endl
             << std::endl;
+
+  test_bit_interleaving<1ul << 20>();
+  std::cout << "passed bit interleaving test !" << std::endl;
 
 #if defined SHA1
 


### PR DESCRIPTION
Following section 2.1 of https://keccak.team/files/Keccak-implementation-3.2.pdf, where bit interleaving technique is defined, I've implemented keccak256 using 32 -bit words i.e. each lane of keccak state array is now represented using two limbs, each of 32 -bit width.

This technique is useful when working on a (virtual) machine which supports only 32 -bit bitwise operations; state array/ round constants to be represented in bit interleaved form. 